### PR TITLE
Set WORKDIR to separate root dir.

### DIFF
--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -3,6 +3,6 @@ FROM raidennetwork/raiden:latest
 COPY . /app/scenario-player
 RUN /opt/venv/bin/pip3 install -r /app/scenario-player/requirements.txt /app/scenario-player
 
-WORKDIR ["/app"]
+WORKDIR ["/run"]
 
 ENTRYPOINT ["/opt/venv/bin/scenario-player"]

--- a/nightly.Dockerfile
+++ b/nightly.Dockerfile
@@ -3,6 +3,6 @@ FROM raidennetwork/raiden:nightly
 COPY . /app/scenario-player
 RUN /opt/venv/bin/pip3 install -r /app/scenario-player/requirements.txt /app/scenario-player
 
-WORKDIR ["/app"]
+WORKDIR ["/run"]
 
 ENTRYPOINT ["/opt/venv/bin/scenario-player"]

--- a/unstable.Dockerfile
+++ b/unstable.Dockerfile
@@ -3,6 +3,6 @@ FROM raidennetwork/raiden:unstable
 COPY . /app/scenario-player
 RUN /opt/venv/bin/pip3 install -r /app/scenario-player/requirements.txt /app/scenario-player
 
-WORKDIR ["/app"]
+WORKDIR ["/run"]
 
 ENTRYPOINT ["/opt/venv/bin/scenario-player"]


### PR DESCRIPTION
Allows simpler exposing of logs from docker container using volumes.