### PR TITLE
Fix logging exception (ConcatenableNone)

### DIFF
--- a/scenario_player/ui.py
+++ b/scenario_player/ui.py
@@ -9,6 +9,7 @@ from structlog.stdlib import ProcessorFormatter
 from urwid import SimpleFocusListWalker
 
 from scenario_player.runner import ScenarioRunner
+from scenario_player.utils import ConcatenableNone
 
 PALETTE = [
     ("log_ts", "default", "default"),
@@ -66,7 +67,7 @@ class SelectableText(uwd.Text):
 
 class UrwidLogWalker(SimpleFocusListWalker):
     def write(self, content):
-        if content is not None:
+        if content not in {None, ConcatenableNone}:
             self.extend(
                 [
                     uwd.AttrMap(SelectableText(line, wrap="clip"), None, focus_map="log_focus")


### PR DESCRIPTION
Python bug [#35046](https://bugs.python.org/issue35046) changed the behavior of the stdlib StreamHandler.
Apparently this change was introduced with Python 3.7.2. Therefore we need to handle both the old and new behaviour.

Stdlib logging change commit: https://github.com/python/cpython/commit/d730719b094cb006711b1cd546927b863c173b31