### PR TITLE
Allow using raiden in local venv.

### DIFF
--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -341,7 +341,7 @@ class NodeRunner:
     def _raiden_bin(self):
         if self._raiden_version.lower() == 'local':
             binary = shutil.which('raiden')
-            if not bin:
+            if not binary:
                 raise FileNotFoundError('Could not use local binary! No Binary found in env!')
             return binary
         return self._runner.release_keeper.get_release(self._raiden_version)

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -339,6 +339,8 @@ class NodeRunner:
 
     @property
     def _raiden_bin(self):
+        if self._raiden_version.lower() == 'local':
+            return shutil.cmd('raiden')
         return self._runner.release_keeper.get_release(self._raiden_version)
 
     @property

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -340,7 +340,10 @@ class NodeRunner:
     @property
     def _raiden_bin(self):
         if self._raiden_version.lower() == 'local':
-            return shutil.cmd('raiden')
+            binary = shutil.which('raiden')
+            if not bin:
+                raise FileNotFoundError('Could not use local binary! No Binary found in env!')
+            return binary
         return self._runner.release_keeper.get_release(self._raiden_version)
 
     @property


### PR DESCRIPTION
Specifying `raiden_version: LOCAL` in the nodes section of the scenario will now use the binary available in the current env.

If there is no binary available in the local env, this will raise a `FileNotFoundError`.

Implements #48 