### PR TITLE
Fix incompatibility with mirakuru 1.1.0

### DIFF
--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -271,7 +271,7 @@ def reclaim_eth(ctx, min_age, password, keystore_file):
     help="Specify the max num of log history you would like to pack. Defaults to 1."
     "Specifying 0 will pack all available logs for a scenario.",
 )
-@click.option("--post-to-rocket/--no-post-to-rocket")
+@click.option("--post-to-rocket/--no-post-to-rocket", default=True)
 @click.argument("scenario-file", type=click.File(), required=True)
 @click.pass_context
 def pack_logs(ctx, scenario_file, post_to_rocket, pack_n_latest, target_dir):

--- a/scenario_player/utils.py
+++ b/scenario_player/utils.py
@@ -161,6 +161,16 @@ class HTTPExecutor(mirakuru.HTTPExecutor):
         self._clear_process()
         return self
 
+    def _set_timeout(self, timeout=None):
+        """
+        Forward ported from mirakuru==1.0.0:mirakuru.base::SimpleExecutor._set_timeout() since
+        the ``timeout`` parameter has been removed in versions >= 1.1.0.
+        """
+        timeout = timeout or self._timeout
+
+        if timeout:
+            self._endtime = time.time() + timeout
+
 
 def wait_for_txs(
     client_or_web3: Union[Web3, JSONRPCClient], txhashes: Set[TransactionHash], timeout: int = 360


### PR DESCRIPTION
Mirakuru 1.1.0 removed the explicit `timeout` parameter on `SimpleExecutor._set_timeout()`.