### PR TITLE
Post download link to logs, instead of uploading.

### DIFF
--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -370,7 +370,7 @@ def construct_rc_message(log_fpath) -> str:
         message = f":x: Error while running scenario: {result}!"
         if exc:
             message += "\n```\n" + exc + "\n```"
-    message += f'\nLog can be downloaded from:\nscenario-player.ci.raiden.network/{str(log_fpath).split("/var/log/scenario-player/")[1]}'
+    message += f'\nLog can be downloaded from:\nhttps://scenario-player.ci.raiden.network/{log_fpath.relative_to("/var/log/scenario-player/")}'
     return message
 
 


### PR DESCRIPTION
Should fix the issue of failing uploads. 

This requires an http server on the CI instance to run and serve the logs folder.

Such a service has been set up.