### PR TITLE
increase wait time for token registration

### DIFF
--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -194,8 +194,8 @@ class ScenarioRunner:
             ).json()
         )
         if self.token_address not in registered_tokens:
-            code, msg = self.register_token(self.token_address, first_node)
             for i in range(5):
+                code, msg = self.register_token(self.token_address, first_node)
                 if 199 < code < 300:
                     break
                 gevent.sleep(1)

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -195,7 +195,11 @@ class ScenarioRunner:
         )
         if self.token_address not in registered_tokens:
             code, msg = self.register_token(self.token_address, first_node)
-            if not 199 < code < 300:
+            for i in range(5):
+                if 199 < code < 300:
+                    break
+                gevent.sleep(1)
+            else:
                 log.error("Couldn't register token with network", code=code, message=msg)
                 raise TokenRegistrationError(msg)
 


### PR DESCRIPTION
This PR aims to fix the problem that we've lately seen with the wait time being too short during token registration. A loop has been introduced that gives some more time for the token registration events to be registered. Since this timeout error only occurs sometimes, it has been difficult to see if the changes fixes the problem, but I haven't able to run into the timeout locally after I added the change.