### PR TITLE
Catch case where no IOU exists

### DIFF
--- a/scenario_player/tasks/services.py
+++ b/scenario_player/tasks/services.py
@@ -289,8 +289,9 @@ class AssertPFSIoUTask(RESTAPIActionTask):
         if self._config.get("iou_exists", True) is False:
             if response_dict:
                 raise ScenarioAssertionError(f"Expected no IOU but got {response_dict}.")
-
-        if "amount" in self._config and "amount" in response_dict:
+        elif not response_dict:
+            raise ScenarioAssertionError(f"Expected IOU, but no IOU exists.")
+        else:
             exp_iou_amount = int(self._config["amount"])
             actual_iou_amount = int(response_dict["amount"])
             if actual_iou_amount != exp_iou_amount:


### PR DESCRIPTION
The `assert_pfs_iou` task had a bug that allowed asserts on non existing IOUs to pass through the if statements and hence wasn't caught. 
This PR should ensure that we catch the cases where no IOU exists.