### PR TITLE
Refactor .yaml config mapping

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,7 @@ serialize = {major}.{minor}.{patch}-{release_type}{iteration}
 tag = True
 commit = True
 message = Cut New Release: {current_version} → {new_version}
-current_version = 0.1.0-dev
+current_version = 0.1.0-dev1
 
 [bumpversion:part:release_type]
 optional_value = stable

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,7 @@ serialize = {major}.{minor}.{patch}-{release_type}{iteration}
 tag = True
 commit = True
 message = Cut New Release: {current_version} → {new_version}
-current_version = 0.1.0-dev1
+current_version = 0.1.0-dev2
 
 [bumpversion:part:release_type]
 optional_value = stable

--- a/scenario_player/__init__.py
+++ b/scenario_player/__init__.py
@@ -3,4 +3,4 @@
 End-to-end testing tool for the ``Raiden`` test suite.
 """
 
-__version__ = "0.1.0-dev"
+__version__ = "0.1.0-dev1"

--- a/scenario_player/__init__.py
+++ b/scenario_player/__init__.py
@@ -3,4 +3,4 @@
 End-to-end testing tool for the ``Raiden`` test suite.
 """
 
-__version__ = "0.1.0-dev1"
+__version__ = "0.1.0-dev2"

--- a/scenario_player/exceptions/config.py
+++ b/scenario_player/exceptions/config.py
@@ -27,7 +27,7 @@ class TokenFileError(ConfigurationError):
 
 
 class TokenSaveError(TokenFileError):
-    """We could not safe the token file, probably because of missing permissions or missing values."""
+    """Could not safe the token file, likely because of missing permissions or missing values."""
 
 
 class TokenFileMissing(TokenFileError):

--- a/scenario_player/exceptions/config.py
+++ b/scenario_player/exceptions/config.py
@@ -32,3 +32,7 @@ class TokenSaveError(TokenFileError):
 
 class TokenFileMissing(TokenFileError):
     """We tried re-using a token, but no token.info file exists for it."""
+
+
+class ServiceConfigurationError(ConfigurationError):
+    """There was a problem validating the services configuration setting."""

--- a/scenario_player/exceptions/config.py
+++ b/scenario_player/exceptions/config.py
@@ -1,0 +1,34 @@
+class ConfigurationError(ValueError):
+    """Generic error thrown if there was an error while reading the scenario file."""
+
+
+class NodeConfigurationError(ConfigurationError):
+    """An error occurred while validating the nodes setting of a scenario file."""
+
+
+class ScenarioConfigurationError(ConfigurationError):
+    """An error occurred while validating the scenario setting of a scenario file."""
+
+
+class TokenConfigurationError(ConfigurationError):
+    """There was a problem while setting up the token contract.
+
+    This may include exceptions which occurred duing file parsing, or during
+    contract creation.
+    """
+
+
+class TokenSourceCodeDoesNotExist(TokenConfigurationError):
+    """The requested address does not contain source code."""
+
+
+class TokenFileError(ConfigurationError):
+    """There was an error while reading a token configuration from disk."""
+
+
+class TokenSaveError(TokenFileError):
+    """We could not safe the token file, probably because of missing permissions or missing values."""
+
+
+class TokenFileMissing(TokenFileError):
+    """We tried re-using a token, but no token.info file exists for it."""

--- a/scenario_player/utils/configuration/base.py
+++ b/scenario_player/utils/configuration/base.py
@@ -1,0 +1,41 @@
+from collections.abc import Mapping
+from typing import Optional, Union
+
+import structlog
+
+from scenario_player.exceptions.config import ConfigurationError
+
+log = structlog.get_logger(__name__)
+
+
+class ConfigMapping(Mapping):
+    def __init__(self, loaded_yaml: Mapping):
+        self.dict = loaded_yaml
+
+    def __getitem__(self, item):
+        return self.dict[item]
+
+    def __iter__(self):
+        return iter(self.dict)
+
+    def __len__(self):
+        return len(self.dict)
+
+    @staticmethod
+    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
+        """Wrap `assert` to raise a ConfigurationError instead of an AssertionError."""
+        try:
+            assert expression
+        except AssertionError as e:
+            if err is None or isinstance(err, str):
+                raise ConfigurationError(err)
+            else:
+                exception = err
+            raise exception from e
+
+    def validate(self):
+        """Validate the configuration.
+
+        Assert that all required keys are present, and no mutually exclusive
+        options were set.
+        """

--- a/scenario_player/utils/configuration/base.py
+++ b/scenario_player/utils/configuration/base.py
@@ -9,6 +9,9 @@ log = structlog.get_logger(__name__)
 
 
 class ConfigMapping(Mapping):
+
+    CONFIGURATION_ERROR = ConfigurationError
+
     def __init__(self, loaded_yaml: Mapping):
         self.dict = loaded_yaml
 
@@ -21,14 +24,14 @@ class ConfigMapping(Mapping):
     def __len__(self):
         return len(self.dict)
 
-    @staticmethod
-    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
+    @classmethod
+    def assert_option(cls, expression, err: Optional[Union[str, Exception]] = None):
         """Wrap `assert` to raise a ConfigurationError instead of an AssertionError."""
         try:
             assert expression
         except AssertionError as e:
             if err is None or isinstance(err, str):
-                raise ConfigurationError(err)
+                raise cls.CONFIGURATION_ERROR(err)
             else:
                 exception = err
             raise exception from e

--- a/scenario_player/utils/configuration/base.py
+++ b/scenario_player/utils/configuration/base.py
@@ -31,7 +31,7 @@ class ConfigMapping(Mapping):
             assert expression
         except AssertionError as e:
             if err is None or isinstance(err, str):
-                raise cls.CONFIGURATION_ERROR(err)
+                raise cls.CONFIGURATION_ERROR(err) from e
             else:
                 exception = err
             raise exception from e

--- a/scenario_player/utils/configuration/nodes.py
+++ b/scenario_player/utils/configuration/nodes.py
@@ -40,11 +40,6 @@ class NodesConfig(ConfigMapping):
         return self.get("node_options", {})
 
     @property
-    def list(self) -> List[str]:
-        """Return the list of nodes configured in the scenario's yaml."""
-        return self["list"]
-
-    @property
     def commands(self) -> dict:
         """Return the commands configured for the nodes."""
         return self.get("commands", {})
@@ -61,5 +56,4 @@ class NodesConfig(ConfigMapping):
 
         """
         self.assert_option(self.dict, "Must specify 'nodes' setting section!")
-        self.assert_option("list" in self.dict, 'Must specify nodes under "list" setting!')
         self.assert_option("count" in self.dict, 'Must specify a "count" setting!')

--- a/scenario_player/utils/configuration/nodes.py
+++ b/scenario_player/utils/configuration/nodes.py
@@ -1,0 +1,70 @@
+from typing import List, Optional, Union
+
+import structlog
+
+from scenario_player.exceptions.config import NodeConfigurationError
+from scenario_player.utils.configuration.base import ConfigMapping
+
+log = structlog.get_logger(__name__)
+
+
+class NodesConfig(ConfigMapping):
+    """Thin wrapper around the 'nodes' setting section of a loaded scenario .yaml file.
+
+    Validates the givne config for missing values and mutually exclusive options.
+
+    :param loaded_yaml: The dict loaded from the scenario yaml file.
+    :param scenario_version: Version of the scenario yaml file.
+    """
+
+    def __init__(self, loaded_yaml: dict):
+        super(NodesConfig, self).__init__(loaded_yaml.get("nodes", {}))
+        self.validate()
+
+    @property
+    def raiden_version(self) -> str:
+        return self.dict.get("raiden_version", "LATEST")
+
+    @property
+    def count(self):
+        return self["count"]
+
+    @property
+    def default_options(self) -> dict:
+        return self.dict.get("default_options", {})
+
+    @property
+    def node_options(self) -> dict:
+        return self.get("node_options", {})
+
+    @property
+    def list(self) -> List[str]:
+        """Return the list of nodes configured in the scenario's yaml."""
+        return self["list"]
+
+    @property
+    def commands(self) -> dict:
+        """Return the commands configured for the nodes."""
+        return self.get("commands", {})
+
+    @staticmethod
+    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
+        """Assert the given expression and raise a NodeConfigurationError if it fails."""
+        if isinstance(err, str):
+            err = NodeConfigurationError(err)
+        return ConfigMapping.assert_option(expression, err)
+
+    def validate(self):
+        """Assert that the given configuration is valid.
+
+        Ensures the following statements are True:
+
+            * The scenario version is > 1
+            * The configuration is not empty
+            * The "list" option is present in the config
+            * The "count" option is present in the config
+
+        """
+        self.assert_option(self.dict, "Must specify 'nodes' setting section!")
+        self.assert_option("list" in self.dict, 'Must specify nodes under "list" setting!')
+        self.assert_option("count" in self.dict, 'Must specify a "count" setting!')

--- a/scenario_player/utils/configuration/nodes.py
+++ b/scenario_player/utils/configuration/nodes.py
@@ -17,6 +17,8 @@ class NodesConfig(ConfigMapping):
     :param scenario_version: Version of the scenario yaml file.
     """
 
+    CONFIGURATION_ERROR = NodeConfigurationError
+
     def __init__(self, loaded_yaml: dict):
         super(NodesConfig, self).__init__(loaded_yaml.get("nodes", {}))
         self.validate()
@@ -46,13 +48,6 @@ class NodesConfig(ConfigMapping):
     def commands(self) -> dict:
         """Return the commands configured for the nodes."""
         return self.get("commands", {})
-
-    @staticmethod
-    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
-        """Assert the given expression and raise a NodeConfigurationError if it fails."""
-        if isinstance(err, str):
-            err = NodeConfigurationError(err)
-        return ConfigMapping.assert_option(expression, err)
 
     def validate(self):
         """Assert that the given configuration is valid.

--- a/scenario_player/utils/configuration/nodes.py
+++ b/scenario_player/utils/configuration/nodes.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Union
-
 import structlog
 
 from scenario_player.exceptions.config import NodeConfigurationError

--- a/scenario_player/utils/configuration/scenario.py
+++ b/scenario_player/utils/configuration/scenario.py
@@ -15,16 +15,11 @@ class ScenarioConfig(ConfigMapping):
     critical errors, such as missing or mutually exclusive keys.
     """
 
+    CONFIGURATION_ERROR = ScenarioConfigurationError
+
     def __init__(self, config: dict) -> None:
         super(ScenarioConfig, self).__init__(config.get("scenario", {}))
         self.validate()
-
-    @staticmethod
-    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
-        """Assert the given expression and raise a ScenarioConfigurationError if it fails."""
-        if isinstance(err, str):
-            err = ScenarioConfigurationError(err)
-        return ConfigMapping.assert_option(expression, err)
 
     def validate(self):
         self.assert_option(self.dict, "Must specify 'scenario' setting section!")

--- a/scenario_player/utils/configuration/scenario.py
+++ b/scenario_player/utils/configuration/scenario.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, Optional, Tuple, Union
+
+import structlog
+
+from scenario_player.exceptions.config import ScenarioConfigurationError
+from scenario_player.utils.configuration.base import ConfigMapping
+
+log = structlog.get_logger(__name__)
+
+
+class ScenarioConfig(ConfigMapping):
+    """Thin wrapper class around the "scenario" setting section of a loaded scenario .yaml file.
+
+    The configuration will automatically be checked for
+    critical errors, such as missing or mutually exclusive keys.
+    """
+
+    def __init__(self, config: dict) -> None:
+        super(ScenarioConfig, self).__init__(config.get("scenario", {}))
+        self.validate()
+
+    @staticmethod
+    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
+        """Assert the given expression and raise a ScenarioConfigurationError if it fails."""
+        if isinstance(err, str):
+            err = ScenarioConfigurationError(err)
+        return ConfigMapping.assert_option(expression, err)
+
+    def validate(self):
+        self.assert_option(self.dict, "Must specify 'scenario' setting section!")
+        self.assert_option(
+            len(self) == 1,
+            "Multiple tasks sections defined in scenario configuration! Must be only one!",
+        )
+
+    @property
+    def root_task(self) -> Tuple[str, Any]:
+        """Return the scenario's root task configuration as a tuple.
+
+        The tuple contains the name of the task, as well as the config for it.
+
+        The root task is the top-level task defined in the 'scenario' key,
+        and typically is one of 'serial' or 'parallel', although this is not
+        a requirement.
+
+        The scenario runner takes care of recursively accessing all sub-tasks
+        of the roo task.
+        """
+        root_task_tuple, = self.items()
+        return root_task_tuple
+
+    @property
+    def root_config(self) -> Dict:
+        """Return the root task config for this scenario's root task."""
+        _, root_task_config = self.root_task
+        return root_task_config
+
+    @property
+    def root_class(self):
+        """Return the Task class type configured for the scenario root task."""
+        from scenario_player.tasks.base import get_task_class_for_type
+
+        root_task_type, _ = self.root_task
+
+        task_class = get_task_class_for_type(root_task_type)
+        return task_class

--- a/scenario_player/utils/configuration/scenario.py
+++ b/scenario_player/utils/configuration/scenario.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple
 
 import structlog
 

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -1,0 +1,66 @@
+from typing import Callable, Optional, Union
+
+import structlog
+
+from scenario_player.constants import TIMEOUT
+from scenario_player.exceptions.config import ScenarioConfigurationError
+from scenario_player.utils import get_gas_price_strategy
+from scenario_player.utils.configuration.base import ConfigMapping
+
+log = structlog.get_logger(__name__)
+
+
+class SettingsConfig(ConfigMapping):
+    """Thin wrapper class around a scenario .yaml file.
+
+    Handles default values as well as exception handling on missing settings.
+
+    The configuration present at the given path will automatically be checked for
+    critical errors, such as missing or mutually exclusive keys.
+    """
+
+    def __init__(self, loaded_yaml: dict) -> None:
+        super(SettingsConfig, self).__init__(loaded_yaml.get("settings", {}))
+        self.validate()
+
+    @staticmethod
+    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
+        """Assert the given expression and raise a ScenarioConfigurationError if it fails."""
+        if isinstance(err, str):
+            err = ScenarioConfigurationError(err)
+        return ConfigMapping.assert_option(expression, err)
+
+    @property
+    def timeout(self) -> int:
+        """Returns the scenario's set timeout in seconds."""
+        return self.get("timeout", TIMEOUT)
+
+    @property
+    def notify(self) -> Union[str, None]:
+        """Return the email address to which notifications are to be sent.
+
+        If this isn't set, we return None.
+        """
+        return self.get("notify")
+
+    @property
+    def chain(self) -> str:
+        """Return the name of the chain to be used for this scenario."""
+        return self.get("chain", "any")
+
+    @property
+    def services(self):
+        """ Return the configuration for raiden services, if available."""
+        return self.get("services", {})
+
+    @property
+    def gas_price(self) -> str:
+        """Return the configured gas price for this scenario.
+
+        This defaults to 'fast'.
+        """
+        return self.get("gas_price", "fast")
+
+    @property
+    def gas_price_strategy(self) -> Callable:
+        return get_gas_price_strategy(self.gas_price)

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -19,16 +19,11 @@ class SettingsConfig(ConfigMapping):
     critical errors, such as missing or mutually exclusive keys.
     """
 
+    CONFIGURATION_ERROR = ScenarioConfigurationError
+
     def __init__(self, loaded_yaml: dict) -> None:
         super(SettingsConfig, self).__init__(loaded_yaml.get("settings", {}))
         self.validate()
-
-    @staticmethod
-    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
-        """Assert the given expression and raise a ScenarioConfigurationError if it fails."""
-        if isinstance(err, str):
-            err = ScenarioConfigurationError(err)
-        return ConfigMapping.assert_option(expression, err)
 
     @property
     def timeout(self) -> int:

--- a/scenario_player/utils/configuration/token.py
+++ b/scenario_player/utils/configuration/token.py
@@ -1,0 +1,74 @@
+import datetime
+import pathlib
+import uuid
+from typing import Optional, Union
+
+import structlog
+
+from scenario_player.exceptions.config import TokenConfigurationError
+from scenario_player.utils.configuration.base import ConfigMapping
+
+log = structlog.get_logger(__name__)
+
+
+class TokenConfig(ConfigMapping):
+    def __init__(self, loaded_yaml: dict, data_path: pathlib.Path):
+        super(TokenConfig, self).__init__(loaded_yaml.get("token", {}))
+        self._token_id = uuid.uuid4()
+        self._name = None
+        self._token_file = data_path.joinpath("token.info")
+        self.validate()
+
+    @staticmethod
+    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
+        """Assert the given expression and raise a NodeConfigurationError if it fails."""
+        if isinstance(err, str):
+            err = TokenConfigurationError(err)
+        return ConfigMapping.assert_option(expression, err)
+
+    def validate(self):
+        """Validate the configuration section.
+
+        Asserts that:
+
+            * Mutually exclusive options are not truthy
+        """
+        mutual_exclusive_ops = ("address", "reuse")
+        if all(option in self.dict for option in mutual_exclusive_ops):
+            self.assert_option(
+                bool(self["address"]) != self["reuse"],
+                f"Token settings {mutual_exclusive_ops} are mutually exclusive.",
+            )
+
+    @property
+    def name(self):
+        if not self._name:
+            now = datetime.datetime.now()
+            self._name = self.get(
+                "name", f"Scenario Test Token {self._token_id!s} {now:%Y-%m-%dT%H:%M}"
+            )
+        return self._name
+
+    @property
+    def address(self):
+        return self.get("address")
+
+    @property
+    def block(self):
+        return self.get("block", 0)
+
+    @property
+    def reuse_token(self):
+        return self.get("reuse", False) and self._token_file.exists()
+
+    @property
+    def save_token(self):
+        return self.get("reuse", False)
+
+    @property
+    def symbol(self):
+        return self.get("symbol", f"T{self._token_id!s:.3}")
+
+    @property
+    def decimals(self):
+        return self.get("decimals", 0)

--- a/scenario_player/utils/configuration/token.py
+++ b/scenario_player/utils/configuration/token.py
@@ -5,6 +5,7 @@ import uuid
 
 import structlog
 
+from scenario_player.constants import DEFAULT_TOKEN_BALANCE_FUND, DEFAULT_TOKEN_BALANCE_MIN
 from scenario_player.exceptions.config import TokenConfigurationError
 from scenario_player.utils.configuration.base import ConfigMapping
 
@@ -89,3 +90,13 @@ class TokenConfig(ConfigMapping):
     @property
     def decimals(self):
         return self.get("decimals", 0)
+
+    @property
+    def min_balance(self):
+        """The required minimum balance required for the scenario run."""
+        return self.get("balance_min", DEFAULT_TOKEN_BALANCE_MIN)
+
+    @property
+    def max_funding(self):
+        """The maximum amount we fund an account with."""
+        return self.get("balance_fund", DEFAULT_TOKEN_BALANCE_FUND)

--- a/scenario_player/utils/configuration/token.py
+++ b/scenario_player/utils/configuration/token.py
@@ -72,10 +72,6 @@ class TokenConfig(ConfigMapping):
         return self.get("address")
 
     @property
-    def block(self):
-        return self.get("block", 0)
-
-    @property
     def reuse_token(self):
         return self.get("reuse", False) and self._token_file.exists()
 

--- a/scenario_player/utils/configuration/token.py
+++ b/scenario_player/utils/configuration/token.py
@@ -12,19 +12,15 @@ log = structlog.get_logger(__name__)
 
 
 class TokenConfig(ConfigMapping):
+
+    CONFIGURATION_ERROR = TokenConfigurationError
+
     def __init__(self, loaded_yaml: dict, data_path: pathlib.Path):
         super(TokenConfig, self).__init__(loaded_yaml.get("token", {}))
         self._token_id = uuid.uuid4()
         self._name = None
         self._token_file = data_path.joinpath("token.info")
         self.validate()
-
-    @staticmethod
-    def assert_option(expression, err: Optional[Union[str, Exception]] = None):
-        """Assert the given expression and raise a NodeConfigurationError if it fails."""
-        if isinstance(err, str):
-            err = TokenConfigurationError(err)
-        return ConfigMapping.assert_option(expression, err)
 
     def validate(self):
         """Validate the configuration section.

--- a/tests/unittests/services/rpc/blueprints/test_instances.py
+++ b/tests/unittests/services/rpc/blueprints/test_instances.py
@@ -9,14 +9,29 @@ def test_transaction_blueprint_is_loaded(transaction_service_client):
 
 
 class TestCreateRPCInstanceEndpoint:
-
     @pytest.mark.parametrize(
         "parameters, expected_status",
         argvalues=[
-            ({"privkey": b"12345678909876543211234567890098", "gas_price_strategy": "super-fast"}, "400"),
+            (
+                {
+                    "privkey": b"12345678909876543211234567890098",
+                    "gas_price_strategy": "super-fast",
+                },
+                "400",
+            ),
             ({"chain_url": "https://test.net", "gas_price_strategy": "super-fast"}, "400"),
-            ({"chain_url": "https://test.net", "privkey": b"12345678909876543211234567890098"}, "200"),
-            ({"chain_url": "https://test.net", "privkey": b"12345678909876543211234567890098", "gas_price_strategy": "super-fast"}, "200"),
+            (
+                {"chain_url": "https://test.net", "privkey": b"12345678909876543211234567890098"},
+                "200",
+            ),
+            (
+                {
+                    "chain_url": "https://test.net",
+                    "privkey": b"12345678909876543211234567890098",
+                    "gas_price_strategy": "super-fast",
+                },
+                "200",
+            ),
         ],
         ids=[
             "missing 'chain_url' is not ok",
@@ -25,24 +40,32 @@ class TestCreateRPCInstanceEndpoint:
             "No missing paramters is ok",
         ],
     )
-    def testcreate_rpc_instance_requires_parameters_specified_in_schema(self, parameters, expected_status, transaction_service_client):
+    def testcreate_rpc_instance_requires_parameters_specified_in_schema(
+        self, parameters, expected_status, transaction_service_client
+    ):
         # Patch the config dict to avoid actually calling the web3 backend.
-        params_as_tuple = tuple(parameters[k] for k in ("chain_url", "privkey", "gas_price_strategy") if k in parameters)
+        params_as_tuple = tuple(
+            parameters[k]
+            for k in ("chain_url", "privkey", "gas_price_strategy")
+            if k in parameters
+        )
         if not len(params_as_tuple) == 3:
             params_as_tuple = (*params_as_tuple, "fast")
 
-        transaction_service_client.application.config["rpc-client"] = {params_as_tuple: (object(), "dummy")}
+        transaction_service_client.application.config["rpc-client"] = {
+            params_as_tuple: (object(), "dummy")
+        }
 
         resp = transaction_service_client.post("/rpc/client", data=parameters)
         assert expected_status in resp.status
 
-    @patch('scenario_player.services.rpc.blueprints.instances.new_instance_schema')
+    @patch("scenario_player.services.rpc.blueprints.instances.new_instance_schema")
     def test_create_rpc_instance_calls_validate_and_deserialize_of_its_schema(
-            self,
-            mock_schema,
-            transaction_service_client,
-            default_create_rpc_instance_request_parameters,
-            deserialized_create_rpc_instance_request_parameters,
+        self,
+        mock_schema,
+        transaction_service_client,
+        default_create_rpc_instance_request_parameters,
+        deserialized_create_rpc_instance_request_parameters,
     ):
         """The :meth:`scenario_player.services.rpc.blueprints.TransactionSendRequest.validate_and_deserialize`
         must be called when processing a request.
@@ -58,8 +81,7 @@ class TestCreateRPCInstanceEndpoint:
             }
         )
         transaction_service_client.post(
-            f"/rpc/client",
-            data=default_create_rpc_instance_request_parameters,
+            f"/rpc/client", data=default_create_rpc_instance_request_parameters
         )
 
         mock_schema.validate_and_deserialize.assert_called_once()
@@ -69,14 +91,14 @@ class TestCreateRPCInstanceEndpoint:
             assert key in default_create_rpc_instance_request_parameters
             assert str(default_create_rpc_instance_request_parameters[key]) == value
 
-    @patch('scenario_player.services.rpc.blueprints.instances.new_instance_schema')
+    @patch("scenario_player.services.rpc.blueprints.instances.new_instance_schema")
     def test_create_rpc_instance_calls_dumps_of_its_schema(
-            self,
-            mock_schema,
-            transaction_service_client,
-            deserialized_create_rpc_instance_request_parameters,
-            default_create_rpc_instance_request_parameters,
-            rpc_client_id,
+        self,
+        mock_schema,
+        transaction_service_client,
+        deserialized_create_rpc_instance_request_parameters,
+        default_create_rpc_instance_request_parameters,
+        rpc_client_id,
     ):
         """The :meth:`scenario_player.services.rpc.blueprints.TransactionSendRequest.dump`
         must be called when processing a request and its result returned by the function.
@@ -89,8 +111,7 @@ class TestCreateRPCInstanceEndpoint:
         )
 
         r = transaction_service_client.post(
-            f"/rpc/client",
-            data=default_create_rpc_instance_request_parameters,
+            f"/rpc/client", data=default_create_rpc_instance_request_parameters
         )
         assert "200" in r.status
         mock_schema.dumps.assert_called_once_with({"rpc_client_id": rpc_client_id})

--- a/tests/unittests/services/rpc/blueprints/test_transactions.py
+++ b/tests/unittests/services/rpc/blueprints/test_transactions.py
@@ -13,16 +13,49 @@ class TestNewTransactionEndpoint:
     """Test Schema validation/serialization, business logic for POST requests to /rpc/client/<client_id>/transactions."""
 
     @pytest.mark.parametrize(
-        'parameters, expected_status',
+        "parameters, expected_status",
         argvalues=[
-            ({"value": 123.0, "to": 'someaddress', "startgas": 2.0}, '404'),
-            ({"to": 'someaddress', "startgas": 2.0, "rpc_client_id": "rpc-client-instance-id"}, '400'),
-            ({"value": 123.0, "startgas": 2.0, "rpc_client_id": "rpc-client-instance-id"}, '400'),
-            ({"value": 123.0, "to": 'someaddress', "rpc_client_id": "rpc-client-instance-id"}, '400'),
-            ({"value": 'wholesome', "to": 'someaddress', "startgas": 2.0, "rpc_client_id": "rpc-client-instance-id"}, '400'),
-            ({"value": 123.0, "to": 'someaddress', "startgas": 'hello', "rpc_client_id": "rpc-client-instance-id"}, '400'),
-            ({"value": 123.0, "to": 'someaddress', "startgas": 'hello', "rpc_client_id": 100}, '400'),
-            ({"value": 123.0, "to": 'someaddress', "startgas": 2.0, "rpc_client_id": "rpc-client-instance-id"}, '200'),
+            ({"value": 123.0, "to": "someaddress", "startgas": 2.0}, "404"),
+            (
+                {"to": "someaddress", "startgas": 2.0, "rpc_client_id": "rpc-client-instance-id"},
+                "400",
+            ),
+            ({"value": 123.0, "startgas": 2.0, "rpc_client_id": "rpc-client-instance-id"}, "400"),
+            (
+                {"value": 123.0, "to": "someaddress", "rpc_client_id": "rpc-client-instance-id"},
+                "400",
+            ),
+            (
+                {
+                    "value": "wholesome",
+                    "to": "someaddress",
+                    "startgas": 2.0,
+                    "rpc_client_id": "rpc-client-instance-id",
+                },
+                "400",
+            ),
+            (
+                {
+                    "value": 123.0,
+                    "to": "someaddress",
+                    "startgas": "hello",
+                    "rpc_client_id": "rpc-client-instance-id",
+                },
+                "400",
+            ),
+            (
+                {"value": 123.0, "to": "someaddress", "startgas": "hello", "rpc_client_id": 100},
+                "400",
+            ),
+            (
+                {
+                    "value": 123.0,
+                    "to": "someaddress",
+                    "startgas": 2.0,
+                    "rpc_client_id": "rpc-client-instance-id",
+                },
+                "200",
+            ),
         ],
         ids=[
             "Unknown 'rpc_client_id'",
@@ -33,10 +66,10 @@ class TestNewTransactionEndpoint:
             "None missing - 'startgas' type incorrect",
             "None missing - 'rpc_client_id' type incorrect",
             "None missing - correct types",
-        ]
+        ],
     )
     def test_endpoint_requires_parameter_and_expects_types(
-            self, parameters, expected_status, transaction_service_client, rpc_client_id,
+        self, parameters, expected_status, transaction_service_client, rpc_client_id
     ):
         """The transactions service's `POST /rpc/transactions` endpoint requires a set of parameters with specific types.
 
@@ -63,20 +96,19 @@ class TestNewTransactionEndpoint:
         if has_client_id is False:
             rpc_client_id = None
         resp = transaction_service_client.post(
-            f'/rpc/client/{rpc_client_id}/transactions',
-            data=parameters,
+            f"/rpc/client/{rpc_client_id}/transactions", data=parameters
         )
 
         assert expected_status in resp.status
 
-    @patch('scenario_player.services.rpc.blueprints.transactions.transaction_send_schema')
+    @patch("scenario_player.services.rpc.blueprints.transactions.transaction_send_schema")
     def test_new_transaction_calls_validate_and_deserialize_of_its_schema(
-            self,
-            mock_schema,
-            transaction_service_client,
-            default_send_tx_request_parameters,
-            deserialized_send_tx_request_parameters,
-            rpc_client_id,
+        self,
+        mock_schema,
+        transaction_service_client,
+        default_send_tx_request_parameters,
+        deserialized_send_tx_request_parameters,
+        rpc_client_id,
     ):
         """The :meth:`scenario_player.services.rpc.blueprints.TransactionSendRequest.validate_and_deserialize`
         must be called when processing a request.
@@ -92,8 +124,7 @@ class TestNewTransactionEndpoint:
             }
         )
         transaction_service_client.post(
-            f"/rpc/client/{rpc_client_id}/transactions",
-            data=default_send_tx_request_parameters,
+            f"/rpc/client/{rpc_client_id}/transactions", data=default_send_tx_request_parameters
         )
 
         mock_schema.validate_and_deserialize.assert_called_once()
@@ -103,14 +134,14 @@ class TestNewTransactionEndpoint:
             assert key in default_send_tx_request_parameters
             assert str(default_send_tx_request_parameters[key]) == value
 
-    @patch('scenario_player.services.rpc.blueprints.transactions.transaction_send_schema')
+    @patch("scenario_player.services.rpc.blueprints.transactions.transaction_send_schema")
     def test_new_transaction_calls_dumps_of_its_schema(
-            self,
-            mock_schema,
-            transaction_service_client,
-            deserialized_send_tx_request_parameters,
-            default_send_tx_request_parameters,
-            rpc_client_id,
+        self,
+        mock_schema,
+        transaction_service_client,
+        deserialized_send_tx_request_parameters,
+        default_send_tx_request_parameters,
+        rpc_client_id,
     ):
         """The :meth:`scenario_player.services.rpc.blueprints.TransactionSendRequest.dump`
         must be called when processing a request and its result returned by the function.
@@ -121,26 +152,27 @@ class TestNewTransactionEndpoint:
                 "dumps.return_value": "ok",
             }
         )
-        expected_tx_hash = b'my_tx_hash'
+        expected_tx_hash = b"my_tx_hash"
 
         r = transaction_service_client.post(
-            f"/rpc/client/{rpc_client_id}/transactions",
-            data=default_send_tx_request_parameters,
+            f"/rpc/client/{rpc_client_id}/transactions", data=default_send_tx_request_parameters
         )
         assert "200" in r.status
         mock_schema.dumps.assert_called_once_with({"tx_hash": expected_tx_hash})
 
-    @patch('scenario_player.services.rpc.blueprints.transactions.TransactionSendRequest')
+    @patch("scenario_player.services.rpc.blueprints.transactions.TransactionSendRequest")
     def test_new_transaction_calls_correct_rpc_client_function(
-            self,
-            mock_schema,
-            transaction_service_client,
-            default_send_tx_request_parameters,
-            deserialized_send_tx_request_parameters,
-            rpc_client_id
+        self,
+        mock_schema,
+        transaction_service_client,
+        default_send_tx_request_parameters,
+        deserialized_send_tx_request_parameters,
+        rpc_client_id,
     ):
         """When sending a POST request, ensure that the endpoint calls the :func:`get_rpc_client` function."""
-        mock_rpc_client = transaction_service_client.application.config["rpc-client"].dict[rpc_client_id]
+        mock_rpc_client = transaction_service_client.application.config["rpc-client"].dict[
+            rpc_client_id
+        ]
         mock_schema.configure_mock(
             **{
                 "validate_and_deserialize.return_value": deserialized_send_tx_request_parameters,
@@ -149,8 +181,9 @@ class TestNewTransactionEndpoint:
         )
 
         transaction_service_client.post(
-            f"/rpc/client/{rpc_client_id}/transactions",
-            data=default_send_tx_request_parameters,
+            f"/rpc/client/{rpc_client_id}/transactions", data=default_send_tx_request_parameters
         )
 
-        mock_rpc_client.send_transaction.assert_called_once_with(**deserialized_send_tx_request_parameters)
+        mock_rpc_client.send_transaction.assert_called_once_with(
+            **deserialized_send_tx_request_parameters
+        )

--- a/tests/unittests/services/rpc/conftest.py
+++ b/tests/unittests/services/rpc/conftest.py
@@ -2,8 +2,8 @@ from unittest import mock
 
 import pytest
 
+from scenario_player.services.rpc.utils import RPCRegistry, generate_hash_key
 from scenario_player.services.utils.factories import construct_flask_app
-from scenario_player.services.rpc.utils import generate_hash_key, RPCRegistry
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def default_create_rpc_instance_request_parameters():
 
 @pytest.fixture
 def deserialized_create_rpc_instance_request_parameters(
-        default_create_rpc_instance_request_parameters
+    default_create_rpc_instance_request_parameters
 ):
     deserialized = dict(default_create_rpc_instance_request_parameters)
     deserialized["privkey"] = deserialized["privkey"].encode("UTF-8")
@@ -27,11 +27,7 @@ def deserialized_create_rpc_instance_request_parameters(
 @pytest.fixture
 def default_send_tx_request_parameters():
     """Default required request parameters for a POST request to /transactions."""
-    parameters = {
-        "to": 'someaddress',
-        "value": 123.0,
-        "startgas": 2.0,
-    }
+    parameters = {"to": "someaddress", "value": 123.0, "startgas": 2.0}
     return parameters
 
 
@@ -45,18 +41,15 @@ def deserialized_send_tx_request_parameters(default_send_tx_request_parameters):
 @pytest.fixture
 def rpc_client_id(deserialized_create_rpc_instance_request_parameters):
     params = deserialized_create_rpc_instance_request_parameters
-    return generate_hash_key(
-        params["chain_url"],
-        params["privkey"]
-    )
+    return generate_hash_key(params["chain_url"], params["privkey"])
 
 
 @pytest.fixture
 def transaction_service_app(rpc_client_id):
     app = construct_flask_app()
-    app.config['TESTING'] = True
-    app.config['rpc-client'] = RPCRegistry()
-    app.config['rpc-client'].dict = {
+    app.config["TESTING"] = True
+    app.config["rpc-client"] = RPCRegistry()
+    app.config["rpc-client"].dict = {
         rpc_client_id: mock.Mock(**{"send_transaction.return_value": b"my_tx_hash"})
     }
     return app

--- a/tests/unittests/services/rpc/schemas/test_transactions.py
+++ b/tests/unittests/services/rpc/schemas/test_transactions.py
@@ -1,23 +1,28 @@
 import pytest
-
 from werkzeug.exceptions import BadRequest
 
 from scenario_player.services.rpc.blueprints.transactions import TransactionSendRequest
 
 
 class TestTransactionSendRequestValidator:
-
-    def test_validator_accepts_correct_input(self, default_send_tx_request_parameters, deserialized_send_tx_request_parameters):
+    def test_validator_accepts_correct_input(
+        self, default_send_tx_request_parameters, deserialized_send_tx_request_parameters
+    ):
         validator = TransactionSendRequest()
-        assert validator.validate_and_deserialize(default_send_tx_request_parameters) == deserialized_send_tx_request_parameters
+        assert (
+            validator.validate_and_deserialize(default_send_tx_request_parameters)
+            == deserialized_send_tx_request_parameters
+        )
 
     def test_validator_raises_validation_error_on_missing_args(self):
         validator = TransactionSendRequest()
-        parameters = {'to': 'some_hash', 'value': 123}
+        parameters = {"to": "some_hash", "value": 123}
         with pytest.raises(BadRequest):
             validator.validate_and_deserialize(parameters)
 
-    def test_validator_raises_validation_error_on_invalid_arg_type(self, default_send_tx_request_parameters):
+    def test_validator_raises_validation_error_on_invalid_arg_type(
+        self, default_send_tx_request_parameters
+    ):
         validator = TransactionSendRequest()
         default_send_tx_request_parameters["value"] = "larry"
         with pytest.raises(BadRequest):
@@ -25,8 +30,8 @@ class TestTransactionSendRequestValidator:
 
     def test_serializer_constructs_correct_output(self):
         serializer = TransactionSendRequest()
-        tx_hash = b'my_tx_hash'
-        given = {'tx_hash': tx_hash}
-        expected_output = {'tx_hash': tx_hash.decode('utf-8')}
+        tx_hash = b"my_tx_hash"
+        given = {"tx_hash": tx_hash}
+        expected_output = {"tx_hash": tx_hash.decode("utf-8")}
         actual = serializer.dump(given)
         assert actual == expected_output

--- a/tests/unittests/services/rpc/test_utils.py
+++ b/tests/unittests/services/rpc/test_utils.py
@@ -1,13 +1,12 @@
-from unittest import mock
 import hashlib
 import hmac
+from unittest import mock
+
 import pytest
 import werkzeug
 
 from raiden.network.rpc.client import JSONRPCClient
-
-from scenario_player.services.rpc.utils import generate_hash_key
-from scenario_player.services.rpc.utils import RPCRegistry
+from scenario_player.services.rpc.utils import RPCRegistry, generate_hash_key
 
 
 @pytest.mark.dependency(name="generate_hash_key_for_transactions_service")
@@ -47,11 +46,16 @@ class TestRPCRegistry:
 
     @pytest.mark.parametrize(
         "valid_tuple",
-        argvalues=[("https://test.net", b"12345678909876543211234567890098"), ("https://test.net", b"12345678909876543211234567890098", "slow")],
+        argvalues=[
+            ("https://test.net", b"12345678909876543211234567890098"),
+            ("https://test.net", b"12345678909876543211234567890098", "slow"),
+        ],
         ids=["2-item tuple", "3-item-tuple"],
     )
     @mock.patch("scenario_player.services.rpc.utils.JSONRPCClient", autospec=True)
-    def test_getitem_with_valid_tuple_creates_stores_and_returns_rpc_instance(self, mock_rpc_client, valid_tuple):
+    def test_getitem_with_valid_tuple_creates_stores_and_returns_rpc_instance(
+        self, mock_rpc_client, valid_tuple
+    ):
 
         registry = RPCRegistry()
         chain_url, privkey, *strategy = valid_tuple

--- a/tests/unittests/utils/configuration/conftest.py
+++ b/tests/unittests/utils/configuration/conftest.py
@@ -17,7 +17,6 @@ def expected_defaults():
         },
         "token": {"address": None, "block": 0, "reuse": False, "symbol": str(), "decimals": 0},
         "nodes": {
-            "list": [],
             "count": 1,
             "commands": {},
             "default_options": {},
@@ -34,5 +33,5 @@ def minimal_yaml_dict():
         "scenario": {"serial": {"runner": None, "config": "salami"}},
         "settings": {},
         "token": {},
-        "nodes": {"list": [], "count": 1},
+        "nodes": {"count": 1},
     }

--- a/tests/unittests/utils/configuration/conftest.py
+++ b/tests/unittests/utils/configuration/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.fixture
+def expected_defaults():
+    return {
+        "version": 2,
+        "name": "<Unnamed Scenario>",
+        "scenario": {"serial": {"runner": None, "config": "salami"}},
+        "settings": {
+            "gas_price": "fast",
+            "timeout": 200,
+            "notify": None,
+            "chain": "any",
+            "services": {},
+        },
+        "token": {"address": None, "block": 0, "reuse": False, "symbol": str(), "decimals": 0},
+        "nodes": {
+            "list": [],
+            "count": 1,
+            "commands": {},
+            "default_options": {},
+            "node_options": {},
+            "raiden_version": "LATEST",
+        },
+    }
+
+
+@pytest.fixture
+def minimal_yaml_dict():
+    return {
+        "scenario": {"serial": {"runner": None, "config": "salami"}},
+        "settings": {},
+        "token": {},
+        "nodes": {"list": [], "count": 1},
+    }

--- a/tests/unittests/utils/configuration/conftest.py
+++ b/tests/unittests/utils/configuration/conftest.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -35,3 +37,12 @@ def minimal_yaml_dict():
         "token": {},
         "nodes": {"count": 1},
     }
+
+
+@pytest.fixture
+def token_info_path(tmp_path):
+    path = tmp_path.joinpath("token.info")
+    path.touch()
+    with path.open("w") as f:
+        json.dump({"token_name": "my_token", "address": "my_address", "block": 0}, f)
+    return path

--- a/tests/unittests/utils/configuration/conftest.py
+++ b/tests/unittests/utils/configuration/conftest.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.fixture
 def expected_defaults():
+    """A dict containing all expected default values for keys of any ConfigMapping."""
     return {
         "version": 2,
         "name": "<Unnamed Scenario>",
@@ -28,6 +29,7 @@ def expected_defaults():
 
 @pytest.fixture
 def minimal_yaml_dict():
+    """A dictionary with the minimum required keys for instantiating any ConfigMapping."""
     return {
         "scenario": {"serial": {"runner": None, "config": "salami"}},
         "settings": {},

--- a/tests/unittests/utils/configuration/test_base.py
+++ b/tests/unittests/utils/configuration/test_base.py
@@ -10,7 +10,7 @@ class TestConfigMapping:
         assert isinstance(ConfigMapping({}), Mapping)
 
     def test_assert_option_raises_exception_if_expression_is_false(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ConfigurationError):
             ConfigMapping.assert_option(True is False)
 
     def test_assert_option_completes_silently_if_expression_is_true(self):
@@ -21,6 +21,6 @@ class TestConfigMapping:
         with pytest.raises(ConfigurationError, match=expected_message):
             ConfigMapping.assert_option(True is False, expected_message)
 
-    def test_assert_option_raises_exception_if_exception_instance_is_passed(self):
+    def test_assert_option_raises_custom_exception_if_exception_is_passed(self):
         with pytest.raises(SyntaxError):
             ConfigMapping.assert_option(True is False, SyntaxError)

--- a/tests/unittests/utils/configuration/test_base.py
+++ b/tests/unittests/utils/configuration/test_base.py
@@ -1,0 +1,26 @@
+from collections import Mapping
+
+import pytest
+
+from scenario_player.utils.configuration.base import ConfigMapping, ConfigurationError
+
+
+class TestConfigMapping:
+    def test_class_is_a_mapping(self):
+        assert isinstance(ConfigMapping({}), Mapping)
+
+    def test_assert_option_raises_exception_if_expression_is_false(self):
+        with pytest.raises(AssertionError):
+            ConfigMapping.assert_option(True is False)
+
+    def test_assert_option_completes_silently_if_expression_is_true(self):
+        ConfigMapping.assert_option(True is True)
+
+    def test_assert_option_raises_configuration_error_with_given_message(self):
+        expected_message = "Custom message"
+        with pytest.raises(ConfigurationError, match=expected_message):
+            ConfigMapping.assert_option(True is False, expected_message)
+
+    def test_assert_option_raises_exception_if_exception_instance_is_passed(self):
+        with pytest.raises(SyntaxError):
+            ConfigMapping.assert_option(True is False, SyntaxError)

--- a/tests/unittests/utils/configuration/test_base.py
+++ b/tests/unittests/utils/configuration/test_base.py
@@ -7,20 +7,28 @@ from scenario_player.utils.configuration.base import ConfigMapping, Configuratio
 
 class TestConfigMapping:
     def test_class_is_a_mapping(self):
+        """The class is a subclass of :class:`collections.abc.Mapping`."""
         assert isinstance(ConfigMapping({}), Mapping)
 
     def test_assert_option_raises_exception_if_expression_is_false(self):
-        with pytest.raises(ConfigurationError):
-            ConfigMapping.assert_option(True is False)
+        """:meth:`ConfigMapping.assert_option` raises an exception if expession is False."""
+
+    with pytest.raises(ConfigurationError):
+        ConfigMapping.assert_option(True is False)
 
     def test_assert_option_completes_silently_if_expression_is_true(self):
-        ConfigMapping.assert_option(True is True)
+        """:meth:`ConfigMapping.assert_option` raises no exception if expession is True."""
+
+    ConfigMapping.assert_option(True is True)
 
     def test_assert_option_raises_configuration_error_with_given_message(self):
+        """:meth:`ConfigMapping.assert_option` allows raise :exc:`ConfigurationError`
+        with given message."""
         expected_message = "Custom message"
         with pytest.raises(ConfigurationError, match=expected_message):
             ConfigMapping.assert_option(True is False, expected_message)
 
     def test_assert_option_raises_custom_exception_if_exception_is_passed(self):
+        """:meth:`ConfigMapping.assert_option` allows raising custom exception."""
         with pytest.raises(SyntaxError):
             ConfigMapping.assert_option(True is False, SyntaxError)

--- a/tests/unittests/utils/configuration/test_base.py
+++ b/tests/unittests/utils/configuration/test_base.py
@@ -19,7 +19,7 @@ class TestConfigMapping:
     def test_assert_option_completes_silently_if_expression_is_true(self):
         """:meth:`ConfigMapping.assert_option` raises no exception if expession is True."""
 
-    ConfigMapping.assert_option(True is True)
+    ConfigMapping.assert_option(True)
 
     def test_assert_option_raises_configuration_error_with_given_message(self):
         """:meth:`ConfigMapping.assert_option` allows raise :exc:`ConfigurationError`

--- a/tests/unittests/utils/configuration/test_base.py
+++ b/tests/unittests/utils/configuration/test_base.py
@@ -14,7 +14,7 @@ class TestConfigMapping:
         """:meth:`ConfigMapping.assert_option` raises an exception if expession is False."""
 
     with pytest.raises(ConfigurationError):
-        ConfigMapping.assert_option(True is False)
+        ConfigMapping.assert_option(False)
 
     def test_assert_option_completes_silently_if_expression_is_true(self):
         """:meth:`ConfigMapping.assert_option` raises no exception if expession is True."""
@@ -26,9 +26,9 @@ class TestConfigMapping:
         with given message."""
         expected_message = "Custom message"
         with pytest.raises(ConfigurationError, match=expected_message):
-            ConfigMapping.assert_option(True is False, expected_message)
+            ConfigMapping.assert_option(False, expected_message)
 
     def test_assert_option_raises_custom_exception_if_exception_is_passed(self):
         """:meth:`ConfigMapping.assert_option` allows raising custom exception."""
         with pytest.raises(SyntaxError):
-            ConfigMapping.assert_option(True is False, SyntaxError)
+            ConfigMapping.assert_option(False, SyntaxError)

--- a/tests/unittests/utils/configuration/test_nodes.py
+++ b/tests/unittests/utils/configuration/test_nodes.py
@@ -27,7 +27,7 @@ class TestNodesConfig:
 
         assert expected_defaults["nodes"][key] == actual
 
-    @pytest.mark.parametrize("key", ["count", "list"])
+    @pytest.mark.parametrize("key", ["count"])
     def test_class_returns_required_keys(self, key, minimal_yaml_dict):
         """Required keys are accessible via identically named class attributes."""
         config = NodesConfig(minimal_yaml_dict)
@@ -39,7 +39,7 @@ class TestNodesConfig:
 
         assert minimal_yaml_dict["nodes"][key] == actual
 
-    @pytest.mark.parametrize("key", ["list", "count"])
+    @pytest.mark.parametrize("key", ["count"])
     def test_missing_required_key_raises_node_configuration_error(self, key, minimal_yaml_dict):
         """OMissing required keys in the config dict raises a NodeConfigurationError."""
         minimal_yaml_dict["nodes"].pop(key)

--- a/tests/unittests/utils/configuration/test_nodes.py
+++ b/tests/unittests/utils/configuration/test_nodes.py
@@ -1,0 +1,46 @@
+import pytest
+
+from scenario_player.exceptions.config import NodeConfigurationError
+from scenario_player.utils.configuration.base import ConfigMapping
+from scenario_player.utils.configuration.nodes import NodesConfig
+
+
+class TestNodesConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        assert isinstance(NodesConfig(minimal_yaml_dict), ConfigMapping)
+
+    @pytest.mark.parametrize(
+        "key", ["default_options", "node_options", "raiden_version", "commands"]
+    )
+    def test_class_returns_expected_default_for_key(
+        self, key, expected_defaults, minimal_yaml_dict
+    ):
+        config = NodesConfig(minimal_yaml_dict)
+
+        try:
+            actual = getattr(config, key)
+        except AttributeError as e:
+            raise AssertionError(e)
+
+        assert expected_defaults["nodes"][key] == actual
+
+    @pytest.mark.parametrize("key", ["count", "list"])
+    def test_class_returns_required_keys(self, key, minimal_yaml_dict):
+        config = NodesConfig(minimal_yaml_dict)
+
+        try:
+            actual = getattr(config, key)
+        except AttributeError as e:
+            raise AssertionError(e)
+
+        assert minimal_yaml_dict["nodes"][key] == actual
+
+    @pytest.mark.parametrize("key", ["list", "count"])
+    def test_missing_required_key_raises_node_configuration_error(self, key, minimal_yaml_dict):
+        minimal_yaml_dict.pop(key)
+        with pytest.raises(NodeConfigurationError):
+            NodesConfig(minimal_yaml_dict)
+
+    def test_instantiating_with_an_empty_dict_raises_node_configuration_error(self):
+        with pytest.raises(NodeConfigurationError):
+            NodesConfig({})

--- a/tests/unittests/utils/configuration/test_nodes.py
+++ b/tests/unittests/utils/configuration/test_nodes.py
@@ -37,7 +37,7 @@ class TestNodesConfig:
 
     @pytest.mark.parametrize("key", ["list", "count"])
     def test_missing_required_key_raises_node_configuration_error(self, key, minimal_yaml_dict):
-        minimal_yaml_dict.pop(key)
+        minimal_yaml_dict["nodes"].pop(key)
         with pytest.raises(NodeConfigurationError):
             NodesConfig(minimal_yaml_dict)
 

--- a/tests/unittests/utils/configuration/test_nodes.py
+++ b/tests/unittests/utils/configuration/test_nodes.py
@@ -7,6 +7,7 @@ from scenario_player.utils.configuration.nodes import NodesConfig
 
 class TestNodesConfig:
     def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(NodesConfig(minimal_yaml_dict), ConfigMapping)
 
     @pytest.mark.parametrize(
@@ -15,6 +16,8 @@ class TestNodesConfig:
     def test_class_returns_expected_default_for_key(
         self, key, expected_defaults, minimal_yaml_dict
     ):
+        """If supported  keys are absent, sensible defaults are returned for them when accessing
+        them as a class attribute."""
         config = NodesConfig(minimal_yaml_dict)
 
         try:
@@ -26,6 +29,7 @@ class TestNodesConfig:
 
     @pytest.mark.parametrize("key", ["count", "list"])
     def test_class_returns_required_keys(self, key, minimal_yaml_dict):
+        """Required keys are accessible via identically named class attributes."""
         config = NodesConfig(minimal_yaml_dict)
 
         try:
@@ -37,10 +41,12 @@ class TestNodesConfig:
 
     @pytest.mark.parametrize("key", ["list", "count"])
     def test_missing_required_key_raises_node_configuration_error(self, key, minimal_yaml_dict):
+        """OMissing required keys in the config dict raises a NodeConfigurationError."""
         minimal_yaml_dict["nodes"].pop(key)
         with pytest.raises(NodeConfigurationError):
             NodesConfig(minimal_yaml_dict)
 
     def test_instantiating_with_an_empty_dict_raises_node_configuration_error(self):
+        """Passing the NodeConfig class an empty dict is not allowed."""
         with pytest.raises(NodeConfigurationError):
             NodesConfig({})

--- a/tests/unittests/utils/configuration/test_scenario.py
+++ b/tests/unittests/utils/configuration/test_scenario.py
@@ -1,17 +1,19 @@
 import pytest
 
 from scenario_player.exceptions.config import ScenarioConfigurationError
-from scenario_player.tasks.execution import ParallelTask, SerialTask
 from scenario_player.utils.configuration.base import ConfigMapping
 from scenario_player.utils.configuration.scenario import ScenarioConfig
 
 
 class TestScenarioConfig:
     def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(ScenarioConfig(minimal_yaml_dict), ConfigMapping)
 
     @pytest.mark.xfail
     def test_class_loads_root_task_type_correctly(self, minimal_yaml_dict):
+        """Root tasks are checked for validity when accessing the
+        :attr:`ScenarionConfig.root_class` attirbute."""
         task_name = "serial", "parallel"
         minimal_yaml_dict["scenario"] = {task_name: {}}
         config = ScenarioConfig(minimal_yaml_dict)
@@ -22,21 +24,26 @@ class TestScenarioConfig:
     def test_class_returns_root_config_correctly_regardless_of_root_task_name(
         self, root_task_key, minimal_yaml_dict
     ):
+        """:attr:`ScenarioConfig.root_config` returns config without checking
+        task_name validity."""
         injected_task_config = {"foo": "bar"}
         minimal_yaml_dict["scenario"] = {root_task_key: injected_task_config}
         config = ScenarioConfig(minimal_yaml_dict)
         assert config.root_config == injected_task_config
 
     def test_missing_required_key_raises_configuration_error(self, minimal_yaml_dict):
+        """Missing required keys in the config dict raises a ScenarioConfigurationError."""
         minimal_yaml_dict["scenario"].pop("serial")
         with pytest.raises(ScenarioConfigurationError):
             ScenarioConfig(minimal_yaml_dict)
 
     def test_instantiating_with_an_empty_dict_raises_configuration_error(self):
+        """Passing the ScenarioConfig class an empty dict is not allowed."""
         with pytest.raises(ScenarioConfigurationError):
             ScenarioConfig({})
 
     def test_defining_multiple_root_tasks_raises_configuration_error(self, minimal_yaml_dict):
+        """Defining multiple root tasks raises a :exc:`ScenarioConfigurationError`."""
         minimal_yaml_dict["scenario"]["second_root"] = {}
         with pytest.raises(ScenarioConfigurationError):
             ScenarioConfig(minimal_yaml_dict)

--- a/tests/unittests/utils/configuration/test_scenario.py
+++ b/tests/unittests/utils/configuration/test_scenario.py
@@ -1,0 +1,44 @@
+import pytest
+
+from scenario_player.exceptions.config import ScenarioConfigurationError
+from scenario_player.tasks.execution import ParallelTask, SerialTask
+from scenario_player.utils.configuration.base import ConfigMapping
+from scenario_player.utils.configuration.scenario import ScenarioConfig
+
+
+class TestScenarioConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        assert isinstance(ScenarioConfig(minimal_yaml_dict), ConfigMapping)
+
+    @pytest.mark.parametrize(
+        "task_name, expected_class", [("serial", SerialTask), ("parallel", ParallelTask)]
+    )
+    def test_class_loads_root_task_type_correctly(
+        self, task_name, expected_class, minimal_yaml_dict
+    ):
+        minimal_yaml_dict["scenario"][task_name] = {}
+        config = ScenarioConfig(minimal_yaml_dict)
+        assert config.root_class == expected_class
+
+    @pytest.mark.parametrize("root_task_key", ["serial", "parallel", "whatever"])
+    def test_class_returns_root_config_correctly_regardless_of_root_task_name(
+        self, root_task_key, minimal_yaml_dict
+    ):
+        injected_task_config = {"foo": "bar"}
+        minimal_yaml_dict["scenario"] = {root_task_key: injected_task_config}
+        config = ScenarioConfig(minimal_yaml_dict)
+        assert config.root_config == injected_task_config
+
+    def test_missing_required_key_raises_configuration_error(self, minimal_yaml_dict):
+        minimal_yaml_dict.pop("tasks")
+        with pytest.raises(ScenarioConfigurationError):
+            ScenarioConfig(minimal_yaml_dict)
+
+    def test_instantiating_with_an_empty_dict_raises_configuration_error(self):
+        with pytest.raises(ScenarioConfigurationError):
+            ScenarioConfig({})
+
+    def test_defining_multiple_root_tasks_raises_configuration_error(self, minimal_yaml_dict):
+        minimal_yaml_dict["scenario"]["second_root"] = {}
+        with pytest.raises(ScenarioConfigurationError):
+            ScenarioConfig(minimal_yaml_dict)

--- a/tests/unittests/utils/configuration/test_scenario.py
+++ b/tests/unittests/utils/configuration/test_scenario.py
@@ -10,15 +10,13 @@ class TestScenarioConfig:
     def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
         assert isinstance(ScenarioConfig(minimal_yaml_dict), ConfigMapping)
 
-    @pytest.mark.parametrize(
-        "task_name, expected_class", [("serial", SerialTask), ("parallel", ParallelTask)]
-    )
-    def test_class_loads_root_task_type_correctly(
-        self, task_name, expected_class, minimal_yaml_dict
-    ):
-        minimal_yaml_dict["scenario"][task_name] = {}
+    @pytest.mark.xfail
+    def test_class_loads_root_task_type_correctly(self, minimal_yaml_dict):
+        task_name = "serial", "parallel"
+        minimal_yaml_dict["scenario"] = {task_name: {}}
         config = ScenarioConfig(minimal_yaml_dict)
-        assert config.root_class == expected_class
+        self.fail("Not testable due to cyclic import issue!")
+        # assert config.root_class == get_task_class_for_type()
 
     @pytest.mark.parametrize("root_task_key", ["serial", "parallel", "whatever"])
     def test_class_returns_root_config_correctly_regardless_of_root_task_name(
@@ -30,7 +28,7 @@ class TestScenarioConfig:
         assert config.root_config == injected_task_config
 
     def test_missing_required_key_raises_configuration_error(self, minimal_yaml_dict):
-        minimal_yaml_dict.pop("tasks")
+        minimal_yaml_dict["scenario"].pop("serial")
         with pytest.raises(ScenarioConfigurationError):
             ScenarioConfig(minimal_yaml_dict)
 

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -8,12 +8,15 @@ from scenario_player.utils.configuration.settings import SettingsConfig
 
 class TestSettingsConfig:
     def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(SettingsConfig(minimal_yaml_dict), ConfigMapping)
 
     @pytest.mark.parametrize("key", ["notify", "timeout", "chain", "services", "gas_price"])
     def test_class_returns_expected_default_for_key(
         self, key, expected_defaults, minimal_yaml_dict
     ):
+        """If supported  keys are absent, sensible defaults are returned for them when accessing
+        them as a class attribute."""
         config = SettingsConfig(minimal_yaml_dict)
 
         try:
@@ -24,6 +27,7 @@ class TestSettingsConfig:
         assert expected_defaults["settings"][key] == actual
 
     def test_gas_price_strategy_returns_a_callable(self, minimal_yaml_dict):
+        """The :attr:`SettingsConfig.gas_price_strategy` returns a callable."""
         config = SettingsConfig(minimal_yaml_dict)
         assert callable(config.gas_price_strategy)
 
@@ -31,6 +35,8 @@ class TestSettingsConfig:
     def test_gas_price_strategy_property_calls_getter_function(
         self, mock_get_strategy, minimal_yaml_dict
     ):
+        """The gas price strategy is dynamically fetched by calling
+        :func:`get_gas_price_strategy` with :attr:`SettingsConfig.gas_price`."""
         config = SettingsConfig(minimal_yaml_dict)
         _ = config.gas_price_strategy
         mock_get_strategy.assert_called_once_with(config.gas_price)

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -3,7 +3,12 @@ from unittest.mock import patch
 import pytest
 
 from scenario_player.utils.configuration.base import ConfigMapping
-from scenario_player.utils.configuration.settings import SettingsConfig
+from scenario_player.utils.configuration.settings import (
+    PFSSettingsConfig,
+    ServiceSettingsConfig,
+    SettingsConfig,
+    UDCSettingsConfig,
+)
 
 
 class TestSettingsConfig:
@@ -11,7 +16,7 @@ class TestSettingsConfig:
         """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(SettingsConfig(minimal_yaml_dict), ConfigMapping)
 
-    @pytest.mark.parametrize("key", ["notify", "timeout", "chain", "services", "gas_price"])
+    @pytest.mark.parametrize("key", ["notify", "timeout", "chain", "gas_price"])
     def test_class_returns_expected_default_for_key(
         self, key, expected_defaults, minimal_yaml_dict
     ):
@@ -25,6 +30,10 @@ class TestSettingsConfig:
             raise AssertionError(e)
 
         assert expected_defaults["settings"][key] == actual
+
+    def test_settings_attr_returns_service_settings_config_instance(self, minimal_yaml_dict):
+        config = SettingsConfig(minimal_yaml_dict)
+        assert isinstance(config.services, ServiceSettingsConfig)
 
     def test_gas_price_strategy_returns_a_callable(self, minimal_yaml_dict):
         """The :attr:`SettingsConfig.gas_price_strategy` returns a callable."""
@@ -40,3 +49,61 @@ class TestSettingsConfig:
         config = SettingsConfig(minimal_yaml_dict)
         _ = config.gas_price_strategy
         mock_get_strategy.assert_called_once_with(config.gas_price)
+
+
+class TestServiceSettingsConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
+        assert isinstance(ServiceSettingsConfig(minimal_yaml_dict), ConfigMapping)
+
+    def test_pfs_attribute_returns_pfs_settings_config(self, minimal_yaml_dict):
+        config = ServiceSettingsConfig(minimal_yaml_dict)
+        assert isinstance(config.pfs, PFSSettingsConfig)
+
+    def test_ucd_attribute_returns_udc_settings_config(self, minimal_yaml_dict):
+        config = ServiceSettingsConfig(minimal_yaml_dict)
+        assert isinstance(config.udc, UDCSettingsConfig)
+
+
+class TestPFSSettingsConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
+        assert isinstance(PFSSettingsConfig(minimal_yaml_dict), ConfigMapping)
+
+    def test_url_attribute_returns_default_none_if_key_absent(self, minimal_yaml_dict):
+        config = PFSSettingsConfig(minimal_yaml_dict)
+        assert config.url is None
+
+    def test_url_attribute_returns_url_key_value_if_key_present(self, minimal_yaml_dict):
+        minimal_yaml_dict["settings"]["services"] = {"pfs": {"url": "custom_url"}}
+        config = PFSSettingsConfig(minimal_yaml_dict)
+        assert config.url == "custom_url"
+
+
+class TestUDCSettingsConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
+        assert isinstance(UDCSettingsConfig(minimal_yaml_dict), ConfigMapping)
+
+    @pytest.mark.parametrize(
+        "key, expected",
+        argvalues=[("enable", False), ("address", None), ("token", {"deposit": False})],
+    )
+    def test_attributes_whose_key_is_absent_return_expected_default(
+        self, key, expected, minimal_yaml_dict
+    ):
+        config = UDCSettingsConfig(minimal_yaml_dict)
+        MISSING = object()
+        assert getattr(config, key, MISSING) == expected
+
+    @pytest.mark.parametrize(
+        "key, expected",
+        argvalues=[("enable", True), ("address", "walahoo"), ("token", {"deposit": True})],
+    )
+    def test_attributes_return_for_key_value_if_key_present(
+        self, key, expected, minimal_yaml_dict
+    ):
+        minimal_yaml_dict["settings"] = {"services": {"udc": {key: expected}}}
+        config = UDCSettingsConfig(minimal_yaml_dict)
+        MISSING = object()
+        assert getattr(config, key, MISSING) == expected

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import pytest
 
-from scenario_player.exceptions.config import NodeConfigurationError
 from scenario_player.utils.configuration.base import ConfigMapping
 from scenario_player.utils.configuration.settings import SettingsConfig
 
@@ -23,10 +22,6 @@ class TestSettingsConfig:
             raise AssertionError(e)
 
         assert expected_defaults["settings"][key] == actual
-
-    def test_instantiating_with_an_empty_dict_raises_scenario_configuration_error(self):
-        with pytest.raises(NodeConfigurationError):
-            SettingsConfig({})
 
     def test_gas_price_strategy_returns_a_callable(self, minimal_yaml_dict):
         config = SettingsConfig(minimal_yaml_dict)

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+
+from scenario_player.exceptions.config import NodeConfigurationError
+from scenario_player.utils.configuration.base import ConfigMapping
+from scenario_player.utils.configuration.settings import SettingsConfig
+
+
+class TestSettingsConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        assert isinstance(SettingsConfig(minimal_yaml_dict), ConfigMapping)
+
+    @pytest.mark.parametrize("key", ["notify", "timeout", "chain", "services", "gas_price"])
+    def test_class_returns_expected_default_for_key(
+        self, key, expected_defaults, minimal_yaml_dict
+    ):
+        config = SettingsConfig(minimal_yaml_dict)
+
+        try:
+            actual = getattr(config, key)
+        except AttributeError as e:
+            raise AssertionError(e)
+
+        assert expected_defaults["settings"][key] == actual
+
+    def test_instantiating_with_an_empty_dict_raises_scenario_configuration_error(self):
+        with pytest.raises(NodeConfigurationError):
+            SettingsConfig({})
+
+    def test_gas_price_strategy_returns_a_callable(self, minimal_yaml_dict):
+        config = SettingsConfig(minimal_yaml_dict)
+        assert callable(config.gas_price_strategy)
+
+    @patch("scenario_player.utils.configuration.settings.get_gas_price_strategy")
+    def test_gas_price_strategy_property_calls_getter_function(
+        self, mock_get_strategy, minimal_yaml_dict
+    ):
+        config = SettingsConfig(minimal_yaml_dict)
+        _ = config.gas_price_strategy
+        mock_get_strategy.assert_called_once_with(config.gas_price)

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import pytest
+
+from scenario_player.exceptions.config import NodeConfigurationError
+from scenario_player.utils.configuration.base import ConfigMapping
+from scenario_player.utils.configuration.token import TokenConfig
+
+
+class TestTokenConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        assert isinstance(TokenConfig(minimal_yaml_dict), ConfigMapping)
+
+    @pytest.mark.parametrize("key", ["address", "block", "decimals"])
+    def test_class_returns_expected_default_for_key(
+        self, key, expected_defaults, minimal_yaml_dict, tmp_path
+    ):
+        config = TokenConfig(minimal_yaml_dict, tmp_path)
+
+        try:
+            actual = getattr(config, key)
+        except AttributeError as e:
+            raise AssertionError(e)
+
+        assert expected_defaults["nodes"][key] == actual
+
+    def test_passing_mutual_exclusive_keys_raises_configuration_error(
+        self, minimal_yaml_dict, tmp_path
+    ):
+        minimal_yaml_dict["token"]["reuse"] = True
+        minimal_yaml_dict["token"]["address"] = "some_address"
+        with pytest.raises(NodeConfigurationError):
+            TokenConfig(minimal_yaml_dict, tmp_path)
+
+    def test_instantiating_with_an_empty_dict_raises_node_configuration_error(self, tmp_path):
+        with pytest.raises(NodeConfigurationError):
+            TokenConfig({}, tmp_path)
+
+    @pytest.mark.parametrize("exists", [(True, False)])
+    @pytest.mark.parametrize("reuse", [(True, False)])
+    def test_reuse_token_property_returns_correct_boolean(
+        self, reuse, exists, minimal_yaml_dict, tmp_path
+    ):
+        if exists:
+            tmp_path.joinpath("token.info").touch()
+        minimal_yaml_dict["token"]["reuse"] = reuse
+
+        config = TokenConfig(minimal_yaml_dict, tmp_path)
+
+        assert config.reuse_token == (reuse and exists)
+
+    @pytest.mark.parametrize("reuse", [True, False])
+    def test_save_token_property_returns_boolean_according_to_reuse_key(
+        self, reuse, minimal_yaml_dict, tmp_path
+    ):
+        minimal_yaml_dict["token"]["reuse"] = reuse
+        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        assert config.save_token == reuse
+
+    def test_symbol_property_uses_token_id_to_generate_symbol_if_not_given_in_config(
+        self, minimal_yaml_dict, tmp_path
+    ):
+        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        assert config.symbol == f"T{config._token_id!s:.3}"
+
+    @patch("scenario_player.utils.configuration.token.uuid.uuid4", return_value="turtles")
+    def test_token_id_is_generated_using_uuid4(self, mock_uuuid4, minimal_yaml_dict, tmp_path):
+        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        mock_uuuid4.assert_called_once()
+        assert config._token_id == "turtles"

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -14,7 +14,7 @@ class TestTokenConfig:
         """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(TokenConfig(minimal_yaml_dict, token_info_path), ConfigMapping)
 
-    @pytest.mark.parametrize("key", ["address", "block", "decimals"])
+    @pytest.mark.parametrize("key", ["address", "decimals"])
     def test_class_returns_expected_default_for_key(
         self, key, expected_defaults, minimal_yaml_dict, token_info_path
     ):

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -9,12 +9,15 @@ from scenario_player.utils.configuration.token import TokenConfig
 
 class TestTokenConfig:
     def test_is_subclass_of_config_mapping(self, minimal_yaml_dict, tmp_path):
+        """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(TokenConfig(minimal_yaml_dict, tmp_path), ConfigMapping)
 
     @pytest.mark.parametrize("key", ["address", "block", "decimals"])
     def test_class_returns_expected_default_for_key(
         self, key, expected_defaults, minimal_yaml_dict, tmp_path
     ):
+        """If supported  keys are absent, sensible defaults are returned for them when accessing
+        them as a class attribute."""
         config = TokenConfig(minimal_yaml_dict, tmp_path)
 
         try:
@@ -37,6 +40,8 @@ class TestTokenConfig:
     def test_reuse_token_property_returns_correct_boolean(
         self, reuse, exists, minimal_yaml_dict, tmp_path
     ):
+        """The :attr:`TokenConfig.reuse_token` returns a boolean depending on
+        the `reuse` key value and the existence of a `token.info` file in the data path."""
         if exists:
             tmp_path.joinpath("token.info").touch()
         minimal_yaml_dict["token"]["reuse"] = reuse
@@ -49,6 +54,8 @@ class TestTokenConfig:
     def test_save_token_property_returns_boolean_according_to_reuse_key(
         self, reuse, minimal_yaml_dict, tmp_path
     ):
+        """The :attr:`TokenConfig.save_token` attribute's value is identical
+        to the `reuse` key value."""
         minimal_yaml_dict["token"]["reuse"] = reuse
         config = TokenConfig(minimal_yaml_dict, tmp_path)
         assert config.save_token == reuse
@@ -56,11 +63,13 @@ class TestTokenConfig:
     def test_symbol_property_uses_token_id_to_generate_symbol_if_not_given_in_config(
         self, minimal_yaml_dict, tmp_path
     ):
+        """We generate a symbol if none is given, using the token id."""
         config = TokenConfig(minimal_yaml_dict, tmp_path)
         assert config.symbol == f"T{config._token_id!s:.3}"
 
     @patch("scenario_player.utils.configuration.token.uuid.uuid4", return_value="turtles")
     def test_token_id_is_generated_using_uuid4(self, mock_uuuid4, minimal_yaml_dict, tmp_path):
+        """The token_id is generated using :func:`uuid.uuid4()`."""
         config = TokenConfig(minimal_yaml_dict, tmp_path)
         mock_uuuid4.assert_called_once()
         assert config._token_id == "turtles"

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -102,7 +102,7 @@ class TestTokenConfig:
         minimal_yaml_dict["token"]["balance_fund"] = 99
 
         config = TokenConfig(minimal_yaml_dict, token_info_path)
-        assert config.min_balace == 66
+        assert config.min_balance == 66
         assert config.max_funding == 99
 
     def test_balancing_attrs_return_defaults_if_keys_are_absent(
@@ -111,5 +111,5 @@ class TestTokenConfig:
         """The attributes 'min_balance' and `max_funding` return defaults if their keys are absent."""
 
         config = TokenConfig(minimal_yaml_dict, token_info_path)
-        assert config.min_balace == DEFAULT_TOKEN_BALANCE_MIN
+        assert config.min_balance == DEFAULT_TOKEN_BALANCE_MIN
         assert config.max_funding == DEFAULT_TOKEN_BALANCE_FUND

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -2,14 +2,14 @@ from unittest.mock import patch
 
 import pytest
 
-from scenario_player.exceptions.config import NodeConfigurationError
+from scenario_player.exceptions.config import TokenConfigurationError
 from scenario_player.utils.configuration.base import ConfigMapping
 from scenario_player.utils.configuration.token import TokenConfig
 
 
 class TestTokenConfig:
-    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
-        assert isinstance(TokenConfig(minimal_yaml_dict), ConfigMapping)
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict, tmp_path):
+        assert isinstance(TokenConfig(minimal_yaml_dict, tmp_path), ConfigMapping)
 
     @pytest.mark.parametrize("key", ["address", "block", "decimals"])
     def test_class_returns_expected_default_for_key(
@@ -22,22 +22,18 @@ class TestTokenConfig:
         except AttributeError as e:
             raise AssertionError(e)
 
-        assert expected_defaults["nodes"][key] == actual
+        assert expected_defaults["token"][key] == actual
 
     def test_passing_mutual_exclusive_keys_raises_configuration_error(
         self, minimal_yaml_dict, tmp_path
     ):
         minimal_yaml_dict["token"]["reuse"] = True
         minimal_yaml_dict["token"]["address"] = "some_address"
-        with pytest.raises(NodeConfigurationError):
+        with pytest.raises(TokenConfigurationError):
             TokenConfig(minimal_yaml_dict, tmp_path)
 
-    def test_instantiating_with_an_empty_dict_raises_node_configuration_error(self, tmp_path):
-        with pytest.raises(NodeConfigurationError):
-            TokenConfig({}, tmp_path)
-
-    @pytest.mark.parametrize("exists", [(True, False)])
-    @pytest.mark.parametrize("reuse", [(True, False)])
+    @pytest.mark.parametrize("exists", [True, False])
+    @pytest.mark.parametrize("reuse", [True, False])
     def test_reuse_token_property_returns_correct_boolean(
         self, reuse, exists, minimal_yaml_dict, tmp_path
     ):

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import pytest
@@ -8,17 +9,17 @@ from scenario_player.utils.configuration.token import TokenConfig
 
 
 class TestTokenConfig:
-    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict, tmp_path):
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict, token_info_path):
         """The class is a subclass of :class:`ConfigMapping`."""
-        assert isinstance(TokenConfig(minimal_yaml_dict, tmp_path), ConfigMapping)
+        assert isinstance(TokenConfig(minimal_yaml_dict, token_info_path), ConfigMapping)
 
     @pytest.mark.parametrize("key", ["address", "block", "decimals"])
     def test_class_returns_expected_default_for_key(
-        self, key, expected_defaults, minimal_yaml_dict, tmp_path
+        self, key, expected_defaults, minimal_yaml_dict, token_info_path
     ):
         """If supported  keys are absent, sensible defaults are returned for them when accessing
         them as a class attribute."""
-        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
 
         try:
             actual = getattr(config, key)
@@ -28,48 +29,60 @@ class TestTokenConfig:
         assert expected_defaults["token"][key] == actual
 
     def test_passing_mutual_exclusive_keys_raises_configuration_error(
-        self, minimal_yaml_dict, tmp_path
+        self, minimal_yaml_dict, token_info_path
     ):
         minimal_yaml_dict["token"]["reuse"] = True
         minimal_yaml_dict["token"]["address"] = "some_address"
         with pytest.raises(TokenConfigurationError):
-            TokenConfig(minimal_yaml_dict, tmp_path)
+            TokenConfig(minimal_yaml_dict, token_info_path)
 
     @pytest.mark.parametrize("exists", [True, False])
     @pytest.mark.parametrize("reuse", [True, False])
     def test_reuse_token_property_returns_correct_boolean(
-        self, reuse, exists, minimal_yaml_dict, tmp_path
+        self, reuse, exists, minimal_yaml_dict, token_info_path
     ):
         """The :attr:`TokenConfig.reuse_token` returns a boolean depending on
         the `reuse` key value and the existence of a `token.info` file in the data path."""
-        if exists:
-            tmp_path.joinpath("token.info").touch()
+        if not exists:
+            token_info_path.unlink()
         minimal_yaml_dict["token"]["reuse"] = reuse
 
-        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
 
         assert config.reuse_token == (reuse and exists)
 
     @pytest.mark.parametrize("reuse", [True, False])
     def test_save_token_property_returns_boolean_according_to_reuse_key(
-        self, reuse, minimal_yaml_dict, tmp_path
+        self, reuse, minimal_yaml_dict, token_info_path
     ):
         """The :attr:`TokenConfig.save_token` attribute's value is identical
         to the `reuse` key value."""
         minimal_yaml_dict["token"]["reuse"] = reuse
-        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
         assert config.save_token == reuse
 
     def test_symbol_property_uses_token_id_to_generate_symbol_if_not_given_in_config(
-        self, minimal_yaml_dict, tmp_path
+        self, minimal_yaml_dict, token_info_path
     ):
         """We generate a symbol if none is given, using the token id."""
-        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
         assert config.symbol == f"T{config._token_id!s:.3}"
 
     @patch("scenario_player.utils.configuration.token.uuid.uuid4", return_value="turtles")
-    def test_token_id_is_generated_using_uuid4(self, mock_uuuid4, minimal_yaml_dict, tmp_path):
+    def test_token_id_is_generated_using_uuid4(
+        self, mock_uuuid4, minimal_yaml_dict, token_info_path
+    ):
         """The token_id is generated using :func:`uuid.uuid4()`."""
-        config = TokenConfig(minimal_yaml_dict, tmp_path)
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
         mock_uuuid4.assert_called_once()
         assert config._token_id == "turtles"
+
+    def test_name_property_loads_token_name_from_token_info_path_file_if_reuse_token_is_true(
+        self, minimal_yaml_dict, token_info_path
+    ):
+        """Load token name from token info, if available."""
+        minimal_yaml_dict["token"]["reuse"] = True
+        assert token_info_path.exists()
+        assert json.loads(token_info_path.read_text())
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
+        assert config.name == "my_token"

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from scenario_player.constants import DEFAULT_TOKEN_BALANCE_FUND, DEFAULT_TOKEN_BALANCE_MIN
 from scenario_player.exceptions.config import TokenConfigurationError
 from scenario_player.utils.configuration.base import ConfigMapping
 from scenario_player.utils.configuration.token import TokenConfig
@@ -86,3 +87,29 @@ class TestTokenConfig:
         assert json.loads(token_info_path.read_text())
         config = TokenConfig(minimal_yaml_dict, token_info_path)
         assert config.name == "my_token"
+
+    def test_balancing_keys_are_accessible_via_attributes(
+        self, minimal_yaml_dict, token_info_path
+    ):
+        """The keys 'balance_min' and `balance_fund` are accessible via attributes.
+
+        The accessor attributes are:
+
+            * min_balance -> balance_min key
+            * max_funding -> balance_fund key
+        """
+        minimal_yaml_dict["token"]["balance_min"] = 66
+        minimal_yaml_dict["token"]["balance_fund"] = 99
+
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
+        assert config.min_balace == 66
+        assert config.max_funding == 99
+
+    def test_balancing_attrs_return_defaults_if_keys_are_absent(
+        self, minimal_yaml_dict, token_info_path
+    ):
+        """The attributes 'min_balance' and `max_funding` return defaults if their keys are absent."""
+
+        config = TokenConfig(minimal_yaml_dict, token_info_path)
+        assert config.min_balace == DEFAULT_TOKEN_BALANCE_MIN
+        assert config.max_funding == DEFAULT_TOKEN_BALANCE_FUND


### PR DESCRIPTION
Finishes the initial refactoring plan started in scenario_player/scenario.py:

- Exposes scenario.yaml keys as attributes, for easier access
- Validates yaml sections on instantiating
- Implements Mapping interface
- Drops support for version 1 scenarios (#73)

This change is backwards compatible, as it does not touch existing code, but merely adds a new package.