### PR TITLE
Fix drop release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,12 @@ python_deps_cache_key: &python_deps_cache_key
   key: python-deps-{{ checksum "pyproject.toml" }}
 
 # Short-cut to define a main-branches only filter.
-master_dev_release_only: &master_dev_release_only
+master_dev_only: &master_dev_only
   filters:
     branches:
       only:
         - master
         - dev
-        - release
 
 # Short-cut to define a tags-only filter.
 tags_only: &tags_only
@@ -34,7 +33,6 @@ PR_branches_only: &PR_branches_only
       ignore:
         - master
         - dev
-        - release
     tags:
       ignore:
         - /^\d+\.\d+.*/
@@ -278,7 +276,7 @@ workflows:
   Merge-Commit-Workflow:
     jobs:
       - prep-system:
-          <<: *master_dev_release_only
+          <<: *master_dev_only
 
       - validate-commit-message:
           context: Raiden-SP-Context

--- a/.circleci/scripts/bump-part.py
+++ b/.circleci/scripts/bump-part.py
@@ -33,13 +33,11 @@ def get_last_tag():
 
 part = ""
 bump_release_type = None
-if CURRENT_BRANCH in ("dev", "release"):
+if CURRENT_BRANCH == "dev":
     part = "iteration"
     # Make sure we set the correct release type.
-    if CURRENT_BRANCH == "dev" and "dev" not in __version__:
+    if "dev" not in __version__:
         bump_release_type = "dev"
-    elif CURRENT_BRANCH == "release" and "rc" not in __version__:
-        bump_release_type = "rc"
 
 elif CURRENT_BRANCH == "master":
     # Get all commits of the release branch that was merged. If no release
@@ -51,10 +49,10 @@ elif CURRENT_BRANCH == "master":
     print("Available branches: ", branches)
     part = "patch"
 
-    if "release" in branches and COMMIT_TYPE == "RELEASE":
-        print("Found a 'release' branch, checking for feature commits..")
+    if COMMIT_TYPE == "RELEASE":
+        print("Detected RELEASE, checking for feature commits..")
         process_output = subprocess.run(
-            f"git --git-dir={PROJECT_GIT_DIR} log {CURRENT_BRANCH}~1..origin/release --format=%s".split(
+            f"git --git-dir={PROJECT_GIT_DIR} log {CURRENT_BRANCH}~1..origin/dev --format=%s".split(
                 " "
             ),
             check=True,
@@ -66,7 +64,6 @@ elif CURRENT_BRANCH == "master":
                 print("Feature commit detected:\n{line}\nChanging bump type to 'minor'..")
                 part = "minor"
                 break
-
 
 print(f"Bumping part {part}..")
 

--- a/.circleci/scripts/constants.py
+++ b/.circleci/scripts/constants.py
@@ -44,15 +44,6 @@ COMMIT_ISSUE = commit_match.get("ISSUE", "")
 COMMIT_TYPE = (commit_match.get("TYPE", "") or release_match.get("TYPE", "")).upper()
 
 
-# Construct the branch name to use if we need to create PRs programmatically
-# We only do this for RELEASE and HOTFIX type merge commits on master.
-if COMMIT_TYPE == "HOTFIX":
-    NEW_BRANCH = f"{COMMIT_TYPE}-{COMMIT_ISSUE}"
-elif COMMIT_TYPE == "RELEASE":
-    NEW_BRANCH = "release-to-dev"
-else:
-    NEW_BRANCH = os.environ.get("NEW_BRANCH", "")
-
 # GH API auth token.
 GH_AUTH_TOKEN = os.environ["GITHUB_TOKEN"]
 GH_AUTH_HEADERS = {"Authorization": f"token {GH_AUTH_TOKEN}"}

--- a/.circleci/scripts/validate-commit-message.py
+++ b/.circleci/scripts/validate-commit-message.py
@@ -5,6 +5,7 @@ from constants import COMMIT_MSG, COMMIT_TYPE, CURRENT_BRANCH
 
 print(f"Validating commit message {COMMIT_MSG!r}")
 print(f"Parsed commit type: {COMMIT_TYPE}")
+
 if not COMMIT_TYPE:
     # The commit message title does not comply with any of our regexes.
     print("No commit type parsed - the commit message does not comply with the required pattern!")
@@ -12,9 +13,6 @@ if not COMMIT_TYPE:
 
 if COMMIT_TYPE == "VERSION_BUMP":
     print("Commit by bumpversion tool detected, skipping validation..")
-elif CURRENT_BRANCH == "release" and COMMIT_TYPE == "FEAT":
-    print("No feature (FEAT) commits allowed on `release` branches!")
-    exit(1)
 elif CURRENT_BRANCH == "master" and COMMIT_TYPE not in ("HOTFIX", "RELEASE"):
     print("`master` branch allows  hotfixes (HOTFIX) and releases (RELEASE) only!")
     exit(1)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,11 +8,6 @@ Scenario-Player Contributing Guide
 Workflows
 =========
 
-.. admonition:: Required Reading
-
-    Please have a look at `nvie.com's " Successful git branching model" <https://nvie.com/posts/a-successful-git-branching-model>`_ for an in-depth
-    explanation of the branching model we're using in this repository.
-
 ..admonition:: The Golden Rule
 
     For each and every single PR, all of the following must hold true in order to be merged:
@@ -23,6 +18,9 @@ Workflows
 
     If any of these are not true, the PR will not be able to merged. **No exceptions!**
 
+..admonition:: Merge vs Rebase
+
+    The git history is a protocol of our development. As such, it is untouchable.
 
 Features & Fixes
 ----------------
@@ -38,7 +36,6 @@ steps need to be taken:
 6. Open a PR, requesting to merge into **`dev`** .
 7. Wait for feedback or approval.
 
-
 Then, for **Maintainers only**:
 
 8.After approving a PR, merge it using the following REGEX pattern for the commit title:
@@ -51,8 +48,7 @@ Hotfixes
 Hotfixes are a special case in our workflow. They are the only temporary branches
 starting from `master` and going back into it. They also need to be merged into
 `dev`, in order to have that hotfix present in the next release (and avoid possible
-conflicts whem merging `dev` into `master`). Our CI setup partially takes care of
-merging the fix into `dev`, but a human is always required to sign off the PR created by it.
+conflicts whem merging `dev` into `master`).
 The following listing outlines the workflow associated with hotfixes:
 
 1. Fork the project, if you have not already done so.
@@ -69,24 +65,14 @@ Then, for **Maintainers only**:
 
     ^\[(?P<type>HOTFIX)-(?P<issue>#\d+)\]\w?(?P<description>.*)$
 
-8. Open two new PRs requesting to merge into `dev` and `release` (if present).
+8. Open a new PR, requesting to merge into `dev`.
 9. Resolve any conflicts that may arise.
 10. Merge the PRs.
 
 Releases
 --------
 
-Releases are cut from `dev` and merged into `master` at regular intervals. In order
-to allow polishing a release, a new branch is created (`release`), originating
-from `dev`. This branch only takes (HOT)Fix commits, and will reject all others.
-Once polishing is complete, the branch is merged back into `dev` as well as `master`.
-
-1. `git checkout dev`
-2. `git checkout -b release`
-3. `git push -u origin release`
-4. < Let development commence [...]>
-
-Once polishing is complete and we're ready to merge/release:
+Releases are cut from `dev` and merged into `master` at regular intervals.
 
 1. Create a PR from `release` to `master`
 2. Once all checks pass, request a review from a **maintainer**.
@@ -96,11 +82,6 @@ Then, for **Maintainers only**:
 3. if all looks good: merge PR into `master` using the following REGEX for the commit message:
 
     ^\[(?P<type>RELEASE)]\w?(?P<description>.*)$
-
-4. Open a new PR, requesting to merge `release` back into `dev`
-5. Review the PR, and merge after approval using the REGEX from step 3.
-6. Delete the `release` branch after the PR is merged.
-
 
 .. note::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,10 @@ Workflows
 
 ..admonition:: Merge vs Rebase
 
-    The git history is a protocol of our development. As such, it is untouchable.
+    The git history is a protocol of our development. As such, it is untouchable. Never rebase
+    a PR onto `dev` or `master`. What you do on your own branches is your own business, though.
+
+
 
 Features & Fixes
 ----------------


### PR DESCRIPTION
We no longer use `release` branches. Drop them from the CI config and docs.