### PR TITLE
Fix rpc instance generation

### DIFF
--- a/scenario_player/services/rpc/schemas/base.py
+++ b/scenario_player/services/rpc/schemas/base.py
@@ -42,19 +42,18 @@ class RPCClientID(String):
             self.fail("not_hex")
 
         try:
-            client, client_id = current_app.config["rpc-client"][deserialized_string]
+            client = current_app.config["rpc-client"][deserialized_string]
         except KeyError:
             self.fail("unknown_client_id")
 
-        return client, client_id
+        return client
 
     def _serialize(self, value: JSONRPCClient, attr, obj, **kwargs) -> str:
         """Prepare :class:`JSONRPCClient` object for JSON-encoding.
 
         Returns the object's related client id from the config of the flask app.
         """
-        for client_id, client_tuple in current_app.config["rpc-client"].items():
-            client, _ = client_tuple
+        for client_id, client in current_app.config["rpc-client"].items():
             if client == value:
                 return client_id
         self.fail("missing_client_id")
@@ -78,6 +77,6 @@ class RPCCreateResourceSchema(SPSchema):
 
     def validate_and_deserialize(self, data_obj) -> dict:
         deserialized = super(RPCCreateResourceSchema, self).validate_and_deserialize(data_obj)
-        client, client_id = deserialized["client_id"]
-        deserialized["client_id"], deserialized["client"] = client_id, client
+        client = deserialized["client_id"]
+        deserialized["client_id"], deserialized["client"] = client.client_id, client
         return deserialized

--- a/scenario_player/services/rpc/schemas/instances.py
+++ b/scenario_player/services/rpc/schemas/instances.py
@@ -1,7 +1,21 @@
+from marshmallow.exceptions import ValidationError
 from marshmallow.fields import String, Url
 
+from scenario_player.constants import GAS_STRATEGIES
 from scenario_player.services.common.schemas import BytesField, SPSchema
 from scenario_player.services.rpc.schemas.base import RPCClientID, RPCCreateResourceSchema
+
+
+class GasPrice(String):
+    def _deserialize(self, value, attr, data, **kwargs):
+        deserialzed = super(GasPrice, self)._deserialize(value, attr, data, **kwargs)
+        try:
+            return int(deserialzed)
+        except ValueError:
+            key = deserialzed.upper()
+            if key in GAS_STRATEGIES:
+                return key
+            raise ValidationError(f"{value} - not an int-string or known gas price strategy!")
 
 
 class NewInstanceRequest(SPSchema):
@@ -21,7 +35,7 @@ class NewInstanceRequest(SPSchema):
     # Deserialization fields.
     chain_url = Url(required=True, load_only=True)
     privkey = BytesField(required=True, load_only=True)
-    gas_price_strategy = String(required=False, load_only=True, missing="fast")
+    gas_price = GasPrice(required=False, load_only=True, missing="FAST")
 
     # Serialization fields.
     client_id = RPCClientID(required=True, dump_only=True)

--- a/scenario_player/services/rpc/utils.py
+++ b/scenario_player/services/rpc/utils.py
@@ -1,18 +1,35 @@
 import hashlib
 import hmac
 from collections.abc import Mapping
-from typing import Tuple, Union
+from typing import Callable, Tuple, Union
 
 from flask import abort
 from web3 import Web3
 
 from raiden.network.rpc.client import JSONRPCClient
+from scenario_player.constants import GAS_STRATEGIES
 
 
-def generate_hash_key(chain_url: str, privkey: bytes):
-    """Generate a key using the `chain_url` and `privkey` args and the :mod:`hmac` library."""
-    k = hmac.new(privkey, chain_url.encode("UTF-8"), hashlib.sha256)
+def generate_hash_key(chain_url: str, privkey: bytes, strategy: Callable):
+    """Generate a hash key to use as `client_id`, using the :mod:`hmac` library.
+
+    The message is the concatenation of `chain_url` plus the `__name__` attribute of the
+    `strategy`.
+
+    The `privkey` is used to sign it using `sha256`.
+
+    The result is hexdigested before we return it.
+    """
+    k = hmac.new(privkey, (chain_url + strategy.__name__).encode("UTF-8"), hashlib.sha256)
     return k.hexdigest()
+
+
+class RPCClient(JSONRPCClient):
+    def __init__(self, chain_url, privkey, strategy):
+        super(RPCClient, self).__init__(
+            Web3(chain_url), privkey=privkey, gas_price_strategy=strategy
+        )
+        self.client_id = generate_hash_key(chain_url, privkey, strategy)
 
 
 class RPCRegistry(Mapping):
@@ -25,33 +42,37 @@ class RPCRegistry(Mapping):
     def __init__(self):
         self.dict = {}
 
-    def __getitem__(
-        self, item: Union[str, Tuple[str, str], Tuple[str, str, str]]
-    ) -> Tuple[JSONRPCClient, str]:
+    def __getitem__(self, item: Union[str, Tuple[str, str, Callable]]) -> RPCClient:
         try:
-            return self.dict[item], item
+            return self.dict[item]
         except KeyError:
-            if isinstance(item, tuple) and len(item) in range(2, 4):
-                url, privkey, *strategy = item
-                # Strategy may be an empty list if the tuple was only 2 items long.
-                strategy = strategy or "fast"
+            if not self.is_valid_tuple(item):
+                raise
 
-                key = generate_hash_key(url, privkey)
-                if key not in self.dict:
-                    try:
-                        self.dict[key] = JSONRPCClient(
-                            Web3(url), privkey=privkey, gas_price_strategy=strategy
-                        )
-                    except ValueError as e:
-                        abort(400, description=str(e))
-                return self.dict[key], key
-            raise KeyError
+            chain_url, privkey, strategy = item
+            client_id = generate_hash_key(chain_url, privkey, strategy)
+
+            if client_id not in self.dict:
+                self.dict[client_id] = RPCClient(chain_url, privkey, strategy)
+
+            return self.dict[client_id]
 
     def __len__(self):
         return len(self.dict)
 
     def __iter__(self):
         return iter(self.dict)
+
+    def is_valid_tuple(self, t) -> bool:
+        """check if the given tuple can be used to instantiate a new RPC class."""
+        try:
+            chain_url, privkey, strategy = t
+        except (ValueError, TypeError):
+            return False
+        else:
+            if isinstance(chain_url, str) and isinstance(privkey, bytes) and callable(strategy):
+                return True
+            return False
 
     def pop(self, key, default=None):
         return self.dict.pop(key, default)

--- a/scenario_player/services/rpc/utils.py
+++ b/scenario_player/services/rpc/utils.py
@@ -3,11 +3,9 @@ import hmac
 from collections.abc import Mapping
 from typing import Callable, Tuple, Union
 
-from flask import abort
 from web3 import Web3
 
 from raiden.network.rpc.client import JSONRPCClient
-from scenario_player.constants import GAS_STRATEGIES
 
 
 def generate_hash_key(chain_url: str, privkey: bytes, strategy: Callable):

--- a/tests/unittests/services/rpc/blueprints/test_instances.py
+++ b/tests/unittests/services/rpc/blueprints/test_instances.py
@@ -9,56 +9,6 @@ def test_transaction_blueprint_is_loaded(transaction_service_client):
 
 
 class TestCreateRPCInstanceEndpoint:
-    @pytest.mark.parametrize(
-        "parameters, expected_status",
-        argvalues=[
-            (
-                {
-                    "privkey": b"12345678909876543211234567890098",
-                    "gas_price_strategy": "super-fast",
-                },
-                "400",
-            ),
-            ({"chain_url": "https://test.net", "gas_price_strategy": "super-fast"}, "400"),
-            (
-                {"chain_url": "https://test.net", "privkey": b"12345678909876543211234567890098"},
-                "200",
-            ),
-            (
-                {
-                    "chain_url": "https://test.net",
-                    "privkey": b"12345678909876543211234567890098",
-                    "gas_price_strategy": "super-fast",
-                },
-                "200",
-            ),
-        ],
-        ids=[
-            "missing 'chain_url' is not ok",
-            "missing 'privkey'is not ok",
-            "missing 'gas_price_strategy' is ok",
-            "No missing parameters is ok",
-        ],
-    )
-    def testcreate_rpc_instance_requires_parameters_specified_in_schema(
-        self, parameters, expected_status, transaction_service_client
-    ):
-        # Patch the config dict to avoid actually calling the web3 backend.
-        params_as_tuple = tuple(
-            parameters[k]
-            for k in ("chain_url", "privkey", "gas_price_strategy")
-            if k in parameters
-        )
-        if not len(params_as_tuple) == 3:
-            params_as_tuple = (*params_as_tuple, "fast")
-
-        transaction_service_client.application.config["rpc-client"] = {
-            params_as_tuple: (object(), "dummy")
-        }
-
-        resp = transaction_service_client.post("/rpc/client", data=parameters)
-        assert expected_status in resp.status
-
     @patch("scenario_player.services.rpc.blueprints.instances.new_instance_schema")
     def test_create_rpc_instance_calls_validate_and_deserialize_of_its_schema(
         self,

--- a/tests/unittests/services/rpc/blueprints/test_transactions.py
+++ b/tests/unittests/services/rpc/blueprints/test_transactions.py
@@ -69,12 +69,7 @@ class TestNewTransactionEndpoint:
 
         These are as follows:
 
-            - `chain_url` - The url for configuring a Web3 instance, if this is the first
-                transaction sent via the given `run_id`.
-            - `privkey` - the private key required to send the transaction via a
-                :class:`raiden.network.rpc.client.JSONRPCClient` instance.
-            - `gas_price_strategy` - the strategy to set when instantiaing the
-                :class:`raiden.network.rpc.client.JSONRPCClient` instance.
+            - `client_id` - the client id of the RPCClient to use.
             - `to` - a transaction hash, sent as a  `utf-8` encoded :class:`str`.
             - `startgas` - the starting gas to use, as either :class:`int` or :class:`float`.
             - `amount` - the amount to send with the transaction, as either :class:`int` or :class:`float`.

--- a/tests/unittests/services/rpc/conftest.py
+++ b/tests/unittests/services/rpc/conftest.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from scenario_player.constants import GAS_STRATEGIES
 from scenario_player.services.rpc.utils import RPCRegistry, generate_hash_key
 from scenario_player.services.utils.factories import construct_flask_app
 
@@ -11,7 +12,7 @@ def default_create_rpc_instance_request_parameters():
     return {
         "chain_url": "https://test.net",
         "privkey": "my-private-key",
-        "gas_price_strategy": "super-fast",
+        "gas_price_strategy": "fast",
     }
 
 
@@ -37,7 +38,7 @@ def deserialized_send_tx_request_parameters(
 ):
     deserialized = dict(default_send_tx_request_parameters)
     deserialized["to"] = deserialized["to"].encode("UTF-8")
-    deserialized["client"], _ = transaction_service_app.config["rpc-client"][
+    deserialized["client"] = transaction_service_app.config["rpc-client"][
         default_send_tx_request_parameters["client_id"]
     ]
     return deserialized
@@ -53,7 +54,7 @@ def default_send_tx_func_parameters(deserialized_send_tx_request_parameters):
 @pytest.fixture
 def rpc_client_id(deserialized_create_rpc_instance_request_parameters):
     params = deserialized_create_rpc_instance_request_parameters
-    return generate_hash_key(params["chain_url"], params["privkey"])
+    return generate_hash_key(params["chain_url"], params["privkey"], GAS_STRATEGIES["FAST"])
 
 
 @pytest.fixture
@@ -62,7 +63,9 @@ def transaction_service_app(rpc_client_id):
     app.config["TESTING"] = True
     app.config["rpc-client"] = RPCRegistry()
     app.config["rpc-client"].dict = {
-        rpc_client_id: mock.Mock(**{"send_transaction.return_value": b"my_tx_hash"})
+        rpc_client_id: mock.Mock(
+            client_id=rpc_client_id, **{"send_transaction.return_value": b"my_tx_hash"}
+        )
     }
     return app
 

--- a/tests/unittests/services/rpc/schemas/test_base.py
+++ b/tests/unittests/services/rpc/schemas/test_base.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 from flask import current_app
 from werkzeug.exceptions import BadRequest
@@ -32,7 +34,7 @@ def test_rpcclientid_deserializes_to_rpc_client_instance(
     expected = (object(), client_id)
 
     with transaction_service_app.app_context() as app:
-        current_app.config["rpc-client"].dict[client_id] = expected[0]
+        current_app.config["rpc-client"].dict[client_id] = expected
         assert client_id_field._deserialize(client_id, "client_id", {}) == expected
 
 
@@ -81,7 +83,7 @@ def test_rpccreateresourceschema_validate_and_deserialize_adds_client_key_to_unp
     test_schema, transaction_service_app, rpc_client_id
 ):
     client_id = rpc_client_id
-    expected_instance = object()
+    expected_instance = Mock(client_id=client_id)
     input_dict = {"client_id": client_id}
     expected = {"client_id": client_id, "client": expected_instance}
     with transaction_service_app.app_context():

--- a/tests/unittests/services/rpc/schemas/test_instances.py
+++ b/tests/unittests/services/rpc/schemas/test_instances.py
@@ -1,0 +1,94 @@
+import marshmallow as ma
+import pytest
+
+from scenario_player.services.common.schemas import BytesField
+from scenario_player.services.rpc.schemas.base import RPCClientID, RPCCreateResourceSchema
+from scenario_player.services.rpc.schemas.instances import (
+    DeleteInstanceRequest,
+    GasPrice,
+    NewInstanceRequest,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    argvalues=[
+        ("fast", "FAST"),
+        ("MEDIUM", "MEDIUM"),
+        ("MeDiUm", "MEDIUM"),
+        ("4", 4),
+        (4, ma.ValidationError),
+        ("super-fast", ma.ValidationError),
+        (1.5, ma.ValidationError),
+    ],
+    ids=[
+        "Passing known lower-case strategy succeeds",
+        "Passing known upper-case strategy succeeds",
+        "Passing known mixed-case strategy succeeds",
+        "Passing an int as a string succeeds",
+        "Passing an int fails",
+        "Passing an unknown gas strategy fails",
+        "Passing a float fails",
+    ],
+)
+def test_gas_price_field_deserialize_returns_correctly(value, expected):
+    """We expect the GasPrice field to deserialize the input correctly, following
+    these rules:
+
+        * the value must be either a string
+        * If it can be deserialized to an `integer`, it's returned as such.
+        * If the string is a **known** gas-price-strategy name, it is upper-cased and returned.
+        * In all other cases, a ValidationError is raised.
+    """
+    if expected != ma.ValidationError:
+        assert GasPrice()._deserialize(value, "gas_price", {}) == expected
+    else:
+        with pytest.raises(expected):
+            GasPrice()._deserialize(value, "gas_price", {})
+
+
+class TestNewInstanceReuqest:
+    @pytest.mark.parametrize(
+        "field, cls",
+        argvalues=[
+            ("chain_url", ma.fields.Url),
+            ("privkey", BytesField),
+            ("gas_price", GasPrice),
+            ("client_id", RPCClientID),
+        ],
+        ids=[
+            "`chain_url` is a URL field",
+            "`privkey` is a BytesField field",
+            "`gas_price` is a GasPrice field",
+            "`client_id` is a RPCClientID field",
+        ],
+    )
+    def test_fields_are_instances_of_correct_types(self, field, cls):
+        schema_fields = NewInstanceRequest()._declared_fields
+        assert isinstance(schema_fields[field], cls)
+
+    @pytest.mark.parametrize("field", argvalues=["chain_url", "privkey", "gas_price"])
+    def test_field_is_load_only(self, field):
+        schema_fields = NewInstanceRequest()._declared_fields
+        assert schema_fields[field].load_only is True
+
+    def test_client_id_field_is_dump_only(self):
+        schema_fields = NewInstanceRequest()._declared_fields
+        assert schema_fields["client_id"].dump_only is True
+
+    @pytest.mark.parametrize("field", argvalues=["chain_url", "privkey", "client_id"])
+    def test_required_fields_have_their_required_attr_set_to_true(self, field):
+        schema_fields = NewInstanceRequest()._declared_fields
+        assert schema_fields[field].required is True
+
+    def test_optional_gas_price_field_has_its_missing_value_set(self):
+        schema_fields = NewInstanceRequest()._declared_fields
+        assert schema_fields["gas_price"].missing == "FAST"
+
+
+def test_delete_instance_request_schema_inherits_from_rpc_create_resource_schema():
+    """We do not need any additional fields for the request, aside the client_id field.
+
+    This field is load_only by default, which is also exactly what we need.
+    """
+    assert issubclass(DeleteInstanceRequest, RPCCreateResourceSchema)

--- a/tests/unittests/services/rpc/schemas/test_tokens.py
+++ b/tests/unittests/services/rpc/schemas/test_tokens.py
@@ -7,7 +7,7 @@ from raiden.network.rpc.client import JSONRPCClient
 from scenario_player.services.common.schemas import BytesField
 from scenario_player.services.rpc.schemas.base import RPCCreateResourceSchema
 from scenario_player.services.rpc.schemas.tokens import TokenCreateSchema, TokenMintSchema
-from scenario_player.services.rpc.utils import RPCRegistry
+from scenario_player.services.rpc.utils import RPCClient, RPCRegistry
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def base_request_params(hexed_client_id):
 @pytest.fixture
 def deserialized_base_params(app, base_request_params):
     deserialized = dict(base_request_params)
-    deserialized["client"], _ = app.config["rpc-client"][base_request_params["client_id"]]
+    deserialized["client"] = app.config["rpc-client"][base_request_params["client_id"]]
     return deserialized
 
 
@@ -47,7 +47,7 @@ def app(hexed_client_id):
         return "ok"
 
     registry = RPCRegistry()
-    registry.dict[hexed_client_id] = mock.MagicMock(spec=JSONRPCClient)
+    registry.dict[hexed_client_id] = mock.MagicMock(spec=RPCClient, client_id=hexed_client_id)
 
     app = flask.Flask(__name__)
     app.config["TESTING"] = True

--- a/tests/unittests/services/rpc/test_utils.py
+++ b/tests/unittests/services/rpc/test_utils.py
@@ -3,18 +3,20 @@ import hmac
 from unittest import mock
 
 import pytest
-import werkzeug
 
-from raiden.network.rpc.client import JSONRPCClient
-from scenario_player.services.rpc.utils import RPCRegistry, generate_hash_key
+from scenario_player.constants import GAS_STRATEGIES
+from scenario_player.services.rpc.utils import RPCClient, RPCRegistry, generate_hash_key
 
 
 @pytest.mark.dependency(name="generate_hash_key_for_transactions_service")
 def test_generate_hash_key_uses_shalib256_digested_hmac_hexdigests():
     url = "http://test.net"
     privkey = b"my_private_key"
-    expected = hmac.new(privkey, url.encode("UTF-8"), hashlib.sha256).hexdigest()
-    assert generate_hash_key(url, privkey) == expected
+    strategy = GAS_STRATEGIES["FAST"]
+    expected = hmac.new(
+        privkey, (url + strategy.__name__).encode("UTF-8"), hashlib.sha256
+    ).hexdigest()
+    assert generate_hash_key(url, privkey, strategy) == expected
 
 
 class TestRPCRegistry:
@@ -47,25 +49,26 @@ class TestRPCRegistry:
     @pytest.mark.parametrize(
         "valid_tuple",
         argvalues=[
-            ("https://test.net", b"12345678909876543211234567890098"),
-            ("https://test.net", b"12345678909876543211234567890098", "slow"),
+            ("https://test.net", b"12345678909876543211234567890098", GAS_STRATEGIES["FAST"])
         ],
-        ids=["2-item tuple", "3-item-tuple"],
+        ids=["3-item-tuple"],
     )
-    @mock.patch("scenario_player.services.rpc.utils.JSONRPCClient", autospec=True)
+    @mock.patch("scenario_player.services.rpc.utils.JSONRPCClient.__init__")
     def test_getitem_with_valid_tuple_creates_stores_and_returns_rpc_instance(
-        self, mock_rpc_client, valid_tuple
+        self, mock_parent, valid_tuple
     ):
-
         registry = RPCRegistry()
-        chain_url, privkey, *strategy = valid_tuple
-        expected_id = generate_hash_key(chain_url, privkey)
+        chain_url, privkey, strategy = (
+            "https://test.net",
+            b"12345678909876543211234567890098",
+            GAS_STRATEGIES["FAST"],
+        )
+        expected_id = generate_hash_key(chain_url, privkey, strategy)
         # Assert the registry does not have the instance.
         with pytest.raises(KeyError):
             registry[expected_id]
 
-        instance, actual_id = registry[valid_tuple]
-        mock_rpc_client.assert_called_once()
-        assert actual_id == expected_id
-        assert isinstance(instance, JSONRPCClient)
-        assert registry[actual_id] == (instance, actual_id)
+        instance = registry[valid_tuple]
+        assert instance.client_id == expected_id
+        assert isinstance(instance, RPCClient)
+        assert registry[instance.client_id] == instance


### PR DESCRIPTION
Without this fix, we cannot have per-gas-price-strategy instances, which may lead to inconsistent behaviour when concurrently running scenarios on the same chain/private key but with differing gas price strategies.