### PR TITLE
RPC - Use Service for Token Deployment / Minting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ requires = [
     'raiden',
     'structlog',
     'urwid',
+    'waitress',
 ]
 
 # Classifiers, Licensing, keywords for pypi.
@@ -86,7 +87,6 @@ common-service = "scenario_player.services.common.blueprints"
 [tool.flit.scripts]
 # CLI commands installed along with out package.
 scenario_player = "scenario_player.__main__:main"
-
 
 #######################
 # ISORT CONFIGURATION #

--- a/scenario_player/exceptions/services.py
+++ b/scenario_player/exceptions/services.py
@@ -33,7 +33,7 @@ class ServiceError(ConnectionError):
                 message = f"Error communicating with '{service}' at '{service_path}'! {reason}"
                 super(ServiceError, self).__init__(message)
         else:
-            message = "Error communicating with a desired service! {reason}"
+            message = f"Error communicating with a desired service! {reason}"
             super(ServiceError, self).__init__(message)
 
     @property

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -160,8 +160,7 @@ def run(
     collect_tasks(tasks)
 
     # Start our Services
-    service = construct_flask_app()
-    service_process = ServiceProcess(service)
+    service_process = ServiceProcess()
 
     service_process.start()
 

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -28,7 +28,6 @@ from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.exceptions.services import ServiceProcessException
 from scenario_player.runner import ScenarioRunner
 from scenario_player.services.common.app import ServiceProcess
-from scenario_player.services.utils.factories import construct_flask_app
 from scenario_player.tasks.base import collect_tasks
 from scenario_player.ui import ScenarioUI, enable_gui_formatting
 from scenario_player.utils import (

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -280,7 +280,7 @@ class ScenarioRunner:
         self.token.init()
         mint_tx = set()
         for address in node_addresses:
-            tx = self.token.mint(address, gas_limit)
+            tx = self.token.mint(address)
             if tx:
                 mint_tx.add(tx)
 

--- a/scenario_player/services/common/app.py
+++ b/scenario_player/services/common/app.py
@@ -1,10 +1,13 @@
 import multiprocessing as mp
 
 import requests
+import structlog
 import waitress
 
 from scenario_player.exceptions.services import ServiceProcessException
 from scenario_player.services.utils.factories import construct_flask_app
+
+log = structlog.getLogger(__name__)
 
 
 class ServiceProcess(mp.Process):

--- a/scenario_player/services/common/blueprints/admin.py
+++ b/scenario_player/services/common/blueprints/admin.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, Response, request
+from werkzeug.exceptions import InternalServerError
 
 admin_blueprint = Blueprint("admin_view", __name__)
 
@@ -7,7 +8,7 @@ def shutdown_server():
     """Shutdown the server using :func:`werkzeug.server.shutdown`."""
     func = request.environ.get("werkzeug.server.shutdown")
     if func is None:
-        raise RuntimeError("Not running with the Werkzeug Server")
+        raise InternalServerError
     func()
     return Response(response="Server shutting down...", status=200)
 

--- a/scenario_player/services/common/blueprints/metrics.py
+++ b/scenario_player/services/common/blueprints/metrics.py
@@ -6,4 +6,4 @@ metrics_blueprint = Blueprint("metrics_view", __name__)
 
 @metrics_blueprint.route("/metrics", methods=["GET"])
 def metrics_route() -> Response:
-    return Response(generate_latest, mimetype=CONTENT_TYPE_LATEST)
+    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)

--- a/scenario_player/services/rpc/blueprints/__init__.py
+++ b/scenario_player/services/rpc/blueprints/__init__.py
@@ -4,6 +4,7 @@ from scenario_player.constants import HOST_NAMESPACE
 from scenario_player.services.rpc.blueprints.instances import instances_blueprint
 from scenario_player.services.rpc.blueprints.tokens import tokens_blueprint
 from scenario_player.services.rpc.blueprints.transactions import transactions_blueprint
+from scenario_player.services.rpc.utils import RPCRegistry
 
 __all__ = ["transactions_blueprint", "instances_blueprint"]
 
@@ -13,5 +14,6 @@ HOOK_IMPL = pluggy.HookimplMarker(HOST_NAMESPACE)
 
 @HOOK_IMPL
 def register_blueprints(app):
+    app.config["rpc-client"] = RPCRegistry()
     for bp in (transactions_blueprint, instances_blueprint, tokens_blueprint):
         app.register_blueprint(bp)

--- a/scenario_player/services/rpc/blueprints/instances.py
+++ b/scenario_player/services/rpc/blueprints/instances.py
@@ -73,7 +73,7 @@ def rpc_create_view():
 
 
 def create_client():
-    data = new_instance_schema.validate_and_deserialize(request.form)
+    data = new_instance_schema.validate_and_deserialize(request.get_json())
 
     gas_price = data.get("gas_price", "FAST")
 
@@ -127,6 +127,6 @@ def rpc_delete_view():
 
 
 def delete_client(client_id):
-    delete_instance_schema.validate_and_deserialize({"client_id": request.params["client_id"]})
+    delete_instance_schema.validate_and_deserialize({"client_id": request.params.get("client_id")})
     current_app.config["rpc-client"].pop(client_id, None)
     return Response(204)

--- a/scenario_player/services/rpc/blueprints/tokens.py
+++ b/scenario_player/services/rpc/blueprints/tokens.py
@@ -160,14 +160,14 @@ def mint_contract():
           required: true
           schema:
             type: number
-            format: float
+            format: int
 
         - name: amount
           in: query
           required: true
           schema:
             type: number
-            format: float
+            format: int
 
       responses:
         200:

--- a/scenario_player/services/rpc/blueprints/tokens.py
+++ b/scenario_player/services/rpc/blueprints/tokens.py
@@ -251,8 +251,10 @@ def transact_call(data, contract):
     rpc_client = data["client"]
     contract_manager = ContractManager(contracts_precompiled_path())
 
+    log.info("Minting tokens", contract=contract)
     token_abi = contract_manager.get_contract_abi(contract)
     token_proxy = rpc_client.new_contract_proxy(token_abi, data["contract_address"])
+    log.debug("Transacting..", **data)
     return token_proxy.transact(
         transact_actions[contract], data["gas_limit"], data["amount"], data["target_address"]
     )

--- a/scenario_player/services/rpc/schemas/tokens.py
+++ b/scenario_player/services/rpc/schemas/tokens.py
@@ -1,5 +1,5 @@
 from flask_marshmallow import Schema
-from marshmallow.fields import Integer, Nested, Number, String
+from marshmallow.fields import Integer, Nested, String
 
 from scenario_player.services.common.schemas import BytesField
 from scenario_player.services.rpc.schemas.base import RPCCreateResourceSchema
@@ -67,7 +67,7 @@ class TokenMintSchema(RPCCreateResourceSchema):
     # Deserializer fields
     target_address = String(load_only=True, required=True)
     contract_address = String(load_only=True, required=True)
-    amount = Number(load_only=True, required=True)
+    amount = Integer(load_only=True, required=True)
     gas_limit = Integer(load_only=True, required=True)
 
     # Serializer fields

--- a/scenario_player/services/rpc/schemas/tokens.py
+++ b/scenario_player/services/rpc/schemas/tokens.py
@@ -6,25 +6,64 @@ from scenario_player.services.rpc.schemas.base import RPCCreateResourceSchema
 
 
 class ConstructorArgsSchema(Schema):
-    decimals = Integer(required=True, load_only=True)
-    name = String(required=True, load_only=True)
-    symbol = String(required=True, load_only=True)
+    decimals = Integer(required=True)
+    name = String(required=True)
+    symbol = String(required=True)
+
+
+class ContractSchema(Schema):
+    """JSON object representing a deployed contract.
+
+    Parameters:
+
+        - name (string)
+        - address (string)
+    """
+
+    #: name of the deployed contract.
+    name = String(required=True)
+    #: check-summed address of the deployed contract.
+    address = String(required=True)
 
 
 class TokenCreateSchema(RPCCreateResourceSchema):
-    """Validator for POST /rpc/token requests."""
+    """Validator for POST /rpc/token requests.
+
+    Load-only parameters:
+
+        - constructor_args (:class:`ConstructorArgsSchema`)
+        - token_name (string, optional)
+
+    Dump-only parameters:
+
+        - contract (:class:`ContractSchema`)
+        - deployment_block (integer)
+    """
 
     # Deserializer fields
-    constructor_args = Nested(ConstructorArgsSchema, load_only=True)
+    constructor_args = Nested(ConstructorArgsSchema, required=True, load_only=True)
     token_name = String(required=False, missing=None, load_only=True)
 
     # Serializer fields
-    tx_hash = BytesField(required=True, dump_only=True)
+    contract = Nested(ContractSchema, required=True, dump_only=True)
+    deployment_block = Integer(required=True, dump_only=True)
 
 
 class TokenMintSchema(RPCCreateResourceSchema):
-    """Validator for POST /rpc/token/mint requests."""
+    """Validator for POST /rpc/token/mint requests.
 
+    Load-only parameters:
+
+        - token_address (string)
+        - mint_target (string)
+        - amount (number)
+
+    Dump-only parameters:
+
+        - tx_hash (:class:`BytesField`)
+    """
+
+    # Deserializer fields
     token_address = String(load_only=True, required=True)
     mint_target = String(load_only=True, required=True)
     amount = Number(load_only=True, required=True)

--- a/scenario_player/services/rpc/schemas/tokens.py
+++ b/scenario_player/services/rpc/schemas/tokens.py
@@ -68,7 +68,7 @@ class TokenMintSchema(RPCCreateResourceSchema):
     target_address = String(load_only=True, required=True)
     contract_address = String(load_only=True, required=True)
     amount = Number(load_only=True, required=True)
-    gas_limit = Number(load_only=True, required=True)
+    gas_limit = Integer(load_only=True, required=True)
 
     # Serializer fields
     tx_hash = BytesField(required=True, dump_only=True)

--- a/scenario_player/services/rpc/schemas/tokens.py
+++ b/scenario_player/services/rpc/schemas/tokens.py
@@ -54,9 +54,10 @@ class TokenMintSchema(RPCCreateResourceSchema):
 
     Load-only parameters:
 
-        - token_address (string)
-        - mint_target (string)
+        - target_address (string)
+        - contract_address (string)
         - amount (number)
+        - gas_limit (number)
 
     Dump-only parameters:
 
@@ -64,9 +65,10 @@ class TokenMintSchema(RPCCreateResourceSchema):
     """
 
     # Deserializer fields
-    token_address = String(load_only=True, required=True)
-    mint_target = String(load_only=True, required=True)
+    target_address = String(load_only=True, required=True)
+    contract_address = String(load_only=True, required=True)
     amount = Number(load_only=True, required=True)
+    gas_limit = Number(load_only=True, required=True)
 
     # Serializer fields
     tx_hash = BytesField(required=True, dump_only=True)

--- a/scenario_player/services/rpc/utils.py
+++ b/scenario_player/services/rpc/utils.py
@@ -23,7 +23,7 @@ def assign_rpc_instance_id(runner, chain_url, privkey, gas_price):
         "privkey": bytes_to_json_string(privkey),
         "gas_price": gas_price,
     }
-    resp = runner.service_session.post("spaas://rpc/instance", json=params)
+    resp = runner.service_session.post("spaas://rpc/client", json=params)
     client_id = resp.json()["client_id"]
     runner.yaml.settings.services.rpc.client_id = client_id
 

--- a/scenario_player/services/rpc/utils.py
+++ b/scenario_player/services/rpc/utils.py
@@ -28,7 +28,7 @@ def assign_rpc_instance_id(runner, chain_url, privkey, gas_price):
     }
     resp = runner.service_session.post("spaas://rpc/client", json=params)
     client_id = resp.json()["client_id"]
-    runner.yaml.settings.services.rpc.client_id = client_id
+    runner.yaml.spaas.rpc.client_id = client_id
 
 
 def generate_hash_key(chain_url: str, privkey: bytes, strategy: Callable):

--- a/scenario_player/utils/configuration/spaas.py
+++ b/scenario_player/utils/configuration/spaas.py
@@ -38,7 +38,7 @@ class SPaaSServiceConfig(ConfigMapping):
 
     @property
     def host(self):
-        return self.get("host", "localhost")
+        return self.get("host", "127.0.0.1")
 
     @property
     def port(self):

--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -269,7 +269,8 @@ class Token(Contract):
 
         resp = self.interface.post(
             "spaas://rpc/token",
-            params={
+            json={
+                "client_id": self.client_id,
                 "constructor_args": {
                     "decimals": self.decimals,
                     "name": self.name,

--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -29,7 +29,7 @@ class Contract:
 
     @property
     def client_id(self):
-        return self.config.settings.services.rpc.client_id
+        return self.config.spaas.rpc.client_id
 
     @property
     def address(self):

--- a/tests/unittests/services/common/blueprints/test_admin.py
+++ b/tests/unittests/services/common/blueprints/test_admin.py
@@ -1,7 +1,8 @@
 from unittest import mock
-from flask import Response
-import pytest
 
+import pytest
+from flask import Response
+from werkzeug.exceptions import InternalServerError
 
 from scenario_player.services.common.blueprints.admin import admin_blueprint, shutdown_server
 from scenario_player.services.utils.factories import construct_flask_app
@@ -10,35 +11,41 @@ from scenario_player.services.utils.factories import construct_flask_app
 @pytest.fixture
 def client():
     app = construct_flask_app(admin_blueprint)
-    app.config['TESTING'] = True
+    app.config["TESTING"] = True
     client = app.test_client()
 
     return client
 
 
-@mock.patch('scenario_player.services.common.blueprints.admin.shutdown_server', return_value=Response(status=200))
+@mock.patch(
+    "scenario_player.services.common.blueprints.admin.shutdown_server",
+    return_value=Response(status=200),
+)
 def test_shutdown_endpoint_returns_200_when_used_with_werkzeug_server(mock_shutdown, client):
-    response = client.post('/shutdown')
+    response = client.post("/shutdown")
 
     assert response.status_code == 200
     assert mock_shutdown.called
     assert mock_shutdown.call_count == 1
 
 
-@mock.patch('scenario_player.services.common.blueprints.admin.request')
+@mock.patch("scenario_player.services.common.blueprints.admin.request")
 class TestShutdownServerFunc:
-
-    def test_raises_runtime_error_if_no_werkzeug_shutdown_func_avaialable_in_app_environ(self, mock_flask_request):
+    def test_raises_runtime_error_if_no_werkzeug_shutdown_func_avaialable_in_app_environ(
+        self, mock_flask_request
+    ):
         """Our shutdown endpoint only works properly if it's a :mod:`werkzeug`-based server.
 
         Assert that if this is not the case, we raise a :exc:`RunTimeError`.
         """
         mock_flask_request.environ = {}
 
-        with pytest.raises(RuntimeError, match="Not running with the Werkzeug Server"):
+        with pytest.raises(InternalServerError):
             shutdown_server()
 
-    def test_executes_shutdown_sequence_if_werkzeug_shutdown_func_available_in_app_environ(self, mock_flask_request):
+    def test_executes_shutdown_sequence_if_werkzeug_shutdown_func_available_in_app_environ(
+        self, mock_flask_request
+    ):
         """If the server this function is used on is a :mod:`werkzeug`-ased server, make sure we're calling the
         shutdown function available from the app environment."""
         mock_flask_request.environ = {"werkzeug.server.shutdown": mock.Mock()}

--- a/tests/unittests/services/rpc/blueprints/test_instances.py
+++ b/tests/unittests/services/rpc/blueprints/test_instances.py
@@ -31,7 +31,7 @@ class TestCreateRPCInstanceEndpoint:
             }
         )
         transaction_service_client.post(
-            f"/rpc/client", data=default_create_rpc_instance_request_parameters
+            f"/rpc/client", json=default_create_rpc_instance_request_parameters
         )
 
         mock_schema.validate_and_deserialize.assert_called_once()

--- a/tests/unittests/services/rpc/schemas/test_tokens.py
+++ b/tests/unittests/services/rpc/schemas/test_tokens.py
@@ -64,6 +64,35 @@ def app(hexed_client_id):
     return app
 
 
+class TestConstructorArgsSchema:
+    @pytest.mark.parametrize("field", ["decimals", "name", "symbol"])
+    def test_field_is_required(self, field):
+        assert ConstructorArgsSchema._declared_fields[field].required is True
+
+    @pytest.mark.parametrize(
+        "field, field_type",
+        [
+            ("decimals", ma.fields.Integer),
+            ("name", ma.fields.String),
+            ("symbol", ma.fields.String),
+        ],
+    )
+    def test_field_is_expected_type(self, field, field_type):
+        assert type(ConstructorArgsSchema._declared_fields[field]) == field_type
+
+
+class TestContractSchema:
+    @pytest.mark.parametrize("field", ["name", "address"])
+    def test_field_is_required(self, field):
+        assert ContractSchema._declared_fields[field].required is True
+
+    @pytest.mark.parametrize(
+        "field, field_type", [("name", ma.fields.String), ("address", ma.fields.String)]
+    )
+    def test_field_is_expected_type(self, field, field_type):
+        assert type(ContractSchema._declared_fields[field]) == field_type
+
+
 @pytest.mark.parametrize(
     "schema",
     argvalues=[TokenCreateSchema(), TokenMintSchema()],
@@ -88,14 +117,14 @@ class TestTokenCreateSchema:
         argvalues=[("constructor_args", ma.fields.Nested), ("token_name", ma.fields.String)],
     )
     def test_deserializer_fields_are_expected_type(self, field, field_type):
-        assert isinstance(TokenCreateSchema._declared_fields[field], field_type)
+        assert type(TokenCreateSchema._declared_fields[field]) == field_type
 
     @pytest.mark.parametrize(
         "field, field_type",
         argvalues=[("contract", ma.fields.Nested), ("deployment_block", ma.fields.Integer)],
     )
     def test_serializer_fields_are_expected_type(self, field, field_type):
-        assert isinstance(TokenCreateSchema._declared_fields[field], field_type)
+        assert type(TokenCreateSchema._declared_fields[field]) == field_type
 
     @pytest.mark.parametrize(
         "field", argvalues=["constructor_args", "contract", "deployment_block"]
@@ -131,15 +160,15 @@ class TestTokenMintSchema:
             ("target_address", ma.fields.String),
             ("contract_address", ma.fields.String),
             ("gas_limit", ma.fields.Integer),
-            ("amount", ma.fields.Number),
+            ("amount", ma.fields.Integer),
         ],
     )
     def test_deserializer_fields_are_expected_type(self, field, field_type):
-        assert isinstance(TokenMintSchema._declared_fields[field], field_type)
+        assert type(TokenMintSchema._declared_fields[field]) == field_type
 
     @pytest.mark.parametrize("field, field_type", argvalues=[("tx_hash", BytesField)])
     def test_serializer_fields_are_expected_type(self, field, field_type):
-        assert isinstance(TokenMintSchema._declared_fields[field], field_type)
+        assert type(TokenMintSchema._declared_fields[field]) == field_type
 
     @pytest.mark.parametrize(
         "field", argvalues=["target_address", "contract_address", "amount", "gas_limit", "tx_hash"]

--- a/tests/unittests/services/rpc/schemas/test_tokens.py
+++ b/tests/unittests/services/rpc/schemas/test_tokens.py
@@ -130,7 +130,7 @@ class TestTokenMintSchema:
         argvalues=[
             ("target_address", ma.fields.String),
             ("contract_address", ma.fields.String),
-            ("gas_limit", ma.fields.Number),
+            ("gas_limit", ma.fields.Integer),
             ("amount", ma.fields.Number),
         ],
     )

--- a/tests/unittests/services/rpc/schemas/test_tokens.py
+++ b/tests/unittests/services/rpc/schemas/test_tokens.py
@@ -1,12 +1,18 @@
 from unittest import mock
 
 import flask
+import marshmallow as ma
 import pytest
 
 from raiden.network.rpc.client import JSONRPCClient
 from scenario_player.services.common.schemas import BytesField
 from scenario_player.services.rpc.schemas.base import RPCCreateResourceSchema
-from scenario_player.services.rpc.schemas.tokens import TokenCreateSchema, TokenMintSchema
+from scenario_player.services.rpc.schemas.tokens import (
+    ConstructorArgsSchema,
+    ContractSchema,
+    TokenCreateSchema,
+    TokenMintSchema,
+)
 from scenario_player.services.rpc.utils import RPCClient, RPCRegistry
 
 
@@ -64,120 +70,58 @@ def app(hexed_client_id):
     ids=["TokenCreateSchema", "TokenMintSchema"],
 )
 class TestSchemaDefinition:
-    def test_tx_hash_is_bytesfield(self, schema):
-        assert isinstance(schema._declared_fields["tx_hash"], BytesField)
-
-    def test_tx_hash_is_dump_only(self, schema):
-        assert schema._declared_fields["tx_hash"].dump_only is True
-
     def test_schema_inherits_from_rpccreateresourceschema(self, schema):
         assert isinstance(schema, RPCCreateResourceSchema)
 
 
 class TestTokenCreateSchema:
     @pytest.mark.parametrize("field", ["token_name", "constructor_args"])
-    def test_field_is_load_only(self, field):
+    def test_deserializer_field_is_load_only(self, field):
         assert TokenCreateSchema._declared_fields[field].load_only is True
 
-    @pytest.mark.parametrize(
-        "input_dict, expected",
-        argvalues=[
-            (
-                {
-                    "constructor_args": {
-                        "decimals": 6789,
-                        "name": "TokenName",
-                        "symbol": "TokenSymbol",
-                    },
-                    "token_name": "SuperToken",
-                },
-                {
-                    "constructor_args": {
-                        "decimals": 6789,
-                        "name": "TokenName",
-                        "symbol": "TokenSymbol",
-                    },
-                    "token_name": "SuperToken",
-                },
-            ),
-            (
-                {
-                    "constructor_args": {
-                        "decimals": 6789,
-                        "name": "TokenName",
-                        "symbol": "TokenSymbol",
-                    }
-                },
-                {
-                    "constructor_args": {
-                        "decimals": 6789,
-                        "name": "TokenName",
-                        "symbol": "TokenSymbol",
-                    },
-                    "token_name": None,
-                },
-            ),
-        ],
-        ids=["All fields given", "token_name field missing assigns it None"],
-    )
-    def test_validate_and_deserialize_returns_expected_dict(
-        self, input_dict, expected, app, base_request_params, deserialized_base_params
-    ):
-        base_request_params.update(input_dict)
-        deserialized_base_params.update(expected)
-
-        with app.app_context():
-            assert (
-                TokenCreateSchema().validate_and_deserialize(base_request_params)
-                == deserialized_base_params
-            )
+    @pytest.mark.parametrize("field", argvalues=["contract", "deployment_block"])
+    def test_serializer_field_is_dump_only(self, field):
+        assert TokenCreateSchema._declared_fields[field].dump_only is True
 
     @pytest.mark.parametrize(
-        "input_dict",
-        argvalues=[
-            {},
-            {"constructor_args": {"name": "TokenName", "symbol": "TokenSymbol"}},
-            {"constructor_args": {"decimals": 6789, "symbol": "TokenSymbol"}},
-            {"constructor_args": {"decimals": 6789, "name": "TokenName"}},
-            {"constructor_args": {"decimals": 6789, "name": 80085, "symbol": "TokenSymbol"}},
-            {
-                "constructor_args": {
-                    "decimals": "fifty",
-                    "name": "TokenName",
-                    "symbol": "TokenSymbol",
-                }
-            },
-            {"constructor_args": {"decimals": 6789, "name": "TokenName", "symbol": 8000}},
-            {
-                "constructor_args": {
-                    "decimals": 6789,
-                    "name": "TokenName",
-                    "symbol": "TokenSymbol",
-                },
-                "token_name": 5000,
-            },
-        ],
-        ids=[
-            "constructor_args are required",
-            "constructor_args requires decimals key",
-            "constructor_args requires name key",
-            "constructor_args requires symbol key",
-            "constructor_args.deccimals must be an integer",
-            "constructor_args.name must be a string",
-            "constructor_args.symbol must be a string",
-            "token_name must be a string",
-        ],
+        "field, field_type",
+        argvalues=[("constructor_args", ma.fields.Nested), ("token_name", ma.fields.String)],
     )
-    def test_validate_and_deserialize_raises_excpetions_on_faulty_input(self, input_dict, app):
-        with app.test_client() as c:
-            resp = c.post("/test-create", json=input_dict)
-            assert "400 Bad Request".lower() in resp.status.lower()
+    def test_deserializer_fields_are_expected_type(self, field, field_type):
+        assert isinstance(TokenCreateSchema._declared_fields[field], field_type)
+
+    @pytest.mark.parametrize(
+        "field, field_type",
+        argvalues=[("contract", ma.fields.Nested), ("deployment_block", ma.fields.Integer)],
+    )
+    def test_serializer_fields_are_expected_type(self, field, field_type):
+        assert isinstance(TokenCreateSchema._declared_fields[field], field_type)
+
+    @pytest.mark.parametrize(
+        "field", argvalues=["constructor_args", "contract", "deployment_block"]
+    )
+    def test_field_is_required(self, field):
+        assert TokenCreateSchema._declared_fields[field].required is True
+
+    def test_token_name_field_is_optional(self):
+        assert TokenCreateSchema._declared_fields["token_name"].required is False
+
+    @pytest.mark.parametrize(
+        "field, schema",
+        argvalues=[("constructor_args", ConstructorArgsSchema), ("contract", ContractSchema)],
+    )
+    def test_field_nests_correct_schema(self, field, schema):
+        assert TokenCreateSchema._declared_fields[field].nested == schema
 
 
 class TestTokenMintSchema:
     @pytest.mark.parametrize("field", ["token_address", "mint_target", "amount"])
     def test_field_is_load_only(self, field):
         assert TokenMintSchema._declared_fields[field].load_only is True
+
+    @pytest.mark.parametrize("field", ["tx_hash"])
+    def test_field_is_dump_only(self, field):
+        assert TokenMintSchema._declared_fields[field].dump_only is True
 
     def test_validate_and_deserialize_returns_expected_dict(
         self, app, base_request_params, deserialized_base_params
@@ -216,3 +160,9 @@ class TestTokenMintSchema:
         with app.test_client() as c:
             resp = c.post("/test-mint", data=input_dict)
             assert "400 Bad Request".lower() in resp.status.lower()
+
+    def test_tx_hash_is_bytesfield(self):
+        assert isinstance(TokenMintSchema._declared_fields["tx_hash"], BytesField)
+
+    def test_tx_hash_is_dump_only(self):
+        assert TokenMintSchema._declared_fields["tx_hash"].dump_only is True

--- a/tests/unittests/services/utils/test_interface.py
+++ b/tests/unittests/services/utils/test_interface.py
@@ -31,7 +31,9 @@ class TestSPaaSAdapter:
         """If a host and port key have **not** been given in the SPAAS config section,
         SPaaSAdapter.prep_service_request should default to sensible values."""
 
-        expected_url = f"{scheme or 'http'}://{host or 'localhost'}:{port or '5000'}/my-endpoint"
+        expected_url = (
+            f"{scheme or 'http'}://{host or '127.0.0.1'}:{port or '5000'}/{service}/my-endpoint"
+        )
 
         input_config = {}
         if host:
@@ -53,6 +55,7 @@ class TestSPaaSAdapter:
     def test_send_method_monkeypatches_metadata_onto_request(self, mock_adapter_send):
         def return_modded_request(request, *_):
             request.raise_for_status = lambda: True
+            request.json = lambda: True
             return request
 
         mock_adapter_send.side_effect = return_modded_request
@@ -98,5 +101,5 @@ class TestSPaaSAdapter:
         with pytest.raises(expected_err):
             config = SPaaSConfig({"spaas": {}})
             adapter = SPaaSAdapter(config)
-            req = requests.Request(url="http://localhost:5000").prepare()
+            req = requests.Request(url="http://127.0.0.1:5000").prepare()
             adapter.send(req)

--- a/tests/unittests/utils/configuration/test_spaas.py
+++ b/tests/unittests/utils/configuration/test_spaas.py
@@ -5,7 +5,7 @@ from scenario_player.utils.configuration.spaas import SPaaSConfig, SPaaSServiceC
 
 @pytest.mark.parametrize(
     "prop, expected_value",
-    argvalues=[("scheme", "http"), ("port", "5000"), ("netloc", "localhost:5000")],
+    argvalues=[("scheme", "http"), ("port", "5000"), ("netloc", "127.0.0.1:5000")],
 )
 def test_service_config_properties_return_expected_defaults_if_keys_missing(prop, expected_value):
     service_config = SPaaSServiceConfig({})


### PR DESCRIPTION
Integrate the `Token` class into the `ScenarioRunner`, start the `RPC` service in runs, and clean up correctly on shut down.

Please note that this does **not yet** fix `dev`. The integration for the UDC deposits is still missing, and currently the SP will fail during setup with a `Nonce too low` error.