### PR TITLE
Implement UDC balance_per_node and max_funding yaml options.

### DIFF
--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -327,10 +327,10 @@ class ScenarioRunner:
         self.node_controller.initialize_nodes()
         node_addresses = self.node_controller.addresses
         node_count = len(self.node_controller)
-        node_balances = {address: self.client.balance(address) for address in node_addresses}
+        balance_per_nodes = {address: self.client.balance(address) for address in node_addresses}
         low_balances = {
             address: balance
-            for address, balance in node_balances.items()
+            for address, balance in balance_per_nodes.items()
             if balance < NODE_ACCOUNT_BALANCE_MIN
         }
         if low_balances:

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -327,10 +327,10 @@ class ScenarioRunner:
         self.node_controller.initialize_nodes()
         node_addresses = self.node_controller.addresses
         node_count = len(self.node_controller)
-        balance_per_nodes = {address: self.client.balance(address) for address in node_addresses}
+        balance_per_node = {address: self.client.balance(address) for address in node_addresses}
         low_balances = {
             address: balance
-            for address, balance in balance_per_nodes.items()
+            for address, balance in balance_per_node.items()
             if balance < NODE_ACCOUNT_BALANCE_MIN
         }
         if low_balances:

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -49,7 +49,7 @@ class UDCTokenSettings(ConfigMapping):
 
     @property
     def node_balance(self):
-        return self.get("node_balance", 5000)
+        return int(self.get("node_balance", 5000))
 
 
 class UDCSettingsConfig(ConfigMapping):

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -37,6 +37,21 @@ class PFSSettingsConfig(ConfigMapping):
         return self.get("url")
 
 
+class UDCTokenSettings(ConfigMapping):
+    def __init__(self, loaded_yaml: dict):
+        udc_settings = ((loaded_yaml.get("settings") or {}).get("services") or {}).get("udc") or {}
+        super(UDCTokenSettings, self).__init__(udc_settings.get("token"))
+        print(self.dict)
+
+    @property
+    def deposit(self):
+        return self.get("deposit", False)
+
+    @property
+    def node_balance(self):
+        return self.get("node_balance", 5000)
+
+
 class UDCSettingsConfig(ConfigMapping):
     """UDC Service Settings interface.
 
@@ -54,6 +69,7 @@ class UDCSettingsConfig(ConfigMapping):
               address: 0x1000001
               token:
                 deposit: True
+                node_balance: 5000
             ...
     """
 
@@ -61,6 +77,7 @@ class UDCSettingsConfig(ConfigMapping):
         services_dict = (loaded_yaml.get("settings") or {}).get("services") or {}
         super(UDCSettingsConfig, self).__init__(services_dict.get("udc", {}))
         self.validate()
+        self.token = UDCTokenSettings(loaded_yaml)
 
     @property
     def enable(self):
@@ -69,10 +86,6 @@ class UDCSettingsConfig(ConfigMapping):
     @property
     def address(self):
         return self.get("address")
-
-    @property
-    def token(self):
-        return self.get("token", {"deposit": False})
 
 
 class ServiceSettingsConfig(ConfigMapping):

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -48,8 +48,17 @@ class UDCTokenSettings(ConfigMapping):
         return self.get("deposit", False)
 
     @property
-    def node_balance(self):
-        return int(self.get("node_balance", 5000))
+    def balance_per_node(self):
+        """The required amount of UDC/RDN tokens required by each node."""
+        return int(self.get("balance_per_node", 5000))
+
+    @property
+    def max_funding(self):
+        """The maximum amount to fund when depositing RDN tokens at a target.
+
+        It defaults to :attr:`.balance_per_node`'s value.
+        """
+        return int(self.get("max_funding", self.balance_per_node))
 
 
 class UDCSettingsConfig(ConfigMapping):
@@ -69,7 +78,7 @@ class UDCSettingsConfig(ConfigMapping):
               address: 0x1000001
               token:
                 deposit: True
-                node_balance: 5000
+                balance_per_node: 5000
             ...
     """
 

--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -366,7 +366,7 @@ class UserDepositContract(Contract):
         """
         node_count = self.config.nodes.count
         udt_allowance = self.allowance
-        required_allowance = self.config.settings.services.udc.token.node_balance * node_count
+        required_allowance = self.config.settings.services.udc.token.balance_per_node * node_count
 
         log.debug(
             "Checking necessity of deposit request",
@@ -396,8 +396,9 @@ class UserDepositContract(Contract):
 
         TODO: Allow setting max funding parameter, similar to the token `funding_min` setting.
         """
-        balance = self.effective_balance
-        min_deposit = self.config.settings.services.udc.token.node_balance
+        balance = self.effective_balance(target_address)
+        min_deposit = self.config.settings.services.udc.token.balance_per_node
+        max_funding = self.config.settings.services.udc.token.max_funding
         log.debug(
             "Checking necessity of deposit request",
             required_balance=min_deposit,
@@ -408,6 +409,6 @@ class UserDepositContract(Contract):
             return
 
         log.debug("deposit call required - insufficient funds")
-        deposit_amount = min_deposit - balance
+        deposit_amount = max_funding - balance
         params = {"amount": deposit_amount, "target_address": target_address}
         return self.transact("deposit", params)

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -15,7 +15,7 @@ from scenario_player.constants import GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL
 def minimal_yaml_dict():
     """A dictionary with the minimum required keys for instantiating any ConfigMapping."""
     return {
-        "scenario": {"serial": {"runner": None, "config": "salami"}},
+        "scenario": {"serial": {"tasks": {"wait_blocks": {"blocks": 5}}}},
         "settings": {},
         "token": {},
         "nodes": {"count": 1},

--- a/tests/unittests/data/minimal.yaml
+++ b/tests/unittests/data/minimal.yaml
@@ -1,0 +1,9 @@
+scenario:
+  - serial:
+    - tasks: None
+      - wait_block: {"blocks": 5}
+  settings:
+  token:
+  nodes":
+    - count: 1
+  spaas:

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -137,7 +137,8 @@ class TestUDCTokenConfig:
         assert isinstance(UDCTokenSettings(minimal_yaml_dict), ConfigMapping)
 
     @pytest.mark.parametrize(
-        "key, expected", argvalues=[("deposit", True), ("node_balance", 1000)]
+        "key, expected",
+        argvalues=[("deposit", True), ("balance_per_node", 1000), ("max_funding", 10_000)],
     )
     def test_attributes_return_for_key_value_if_key_present(
         self, key, expected, minimal_yaml_dict
@@ -148,7 +149,8 @@ class TestUDCTokenConfig:
         assert getattr(config, key, MISSING) == expected
 
     @pytest.mark.parametrize(
-        "key, expected", argvalues=[("deposit", False), ("node_balance", 5000)]
+        "key, expected",
+        argvalues=[("deposit", False), ("balance_per_node", 5000), ("max_funding", 5000)],
     )
     def test_attributes_whose_key_is_absent_return_expected_default(
         self, key, expected, minimal_yaml_dict

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -10,6 +10,7 @@ from scenario_player.utils.configuration.settings import (
     ServiceSettingsConfig,
     SettingsConfig,
     UDCSettingsConfig,
+    UDCTokenSettings,
 )
 
 
@@ -109,10 +110,10 @@ class TestUDCSettingsConfig:
         """The class is a subclass of :class:`ConfigMapping`."""
         assert isinstance(UDCSettingsConfig(minimal_yaml_dict), ConfigMapping)
 
-    @pytest.mark.parametrize(
-        "key, expected",
-        argvalues=[("enable", False), ("address", None), ("token", {"deposit": False})],
-    )
+    def test_token_attribute_is_an_instance_of_udctokenconfig(self, minimal_yaml_dict):
+        assert isinstance(UDCSettingsConfig(minimal_yaml_dict).token, UDCTokenSettings)
+
+    @pytest.mark.parametrize("key, expected", argvalues=[("enable", False), ("address", None)])
     def test_attributes_whose_key_is_absent_return_expected_default(
         self, key, expected, minimal_yaml_dict
     ):
@@ -120,14 +121,38 @@ class TestUDCSettingsConfig:
         MISSING = object()
         assert getattr(config, key, MISSING) == expected
 
-    @pytest.mark.parametrize(
-        "key, expected",
-        argvalues=[("enable", True), ("address", "walahoo"), ("token", {"deposit": True})],
-    )
+    @pytest.mark.parametrize("key, expected", argvalues=[("enable", True), ("address", "walahoo")])
     def test_attributes_return_for_key_value_if_key_present(
         self, key, expected, minimal_yaml_dict
     ):
         minimal_yaml_dict["settings"] = {"services": {"udc": {key: expected}}}
         config = UDCSettingsConfig(minimal_yaml_dict)
+        MISSING = object()
+        assert getattr(config, key, MISSING) == expected
+
+
+class TestUDCTokenConfig:
+    def test_is_subclass_of_config_mapping(self, minimal_yaml_dict):
+        """The class is a subclass of :class:`ConfigMapping`."""
+        assert isinstance(UDCTokenSettings(minimal_yaml_dict), ConfigMapping)
+
+    @pytest.mark.parametrize(
+        "key, expected", argvalues=[("deposit", True), ("node_balance", 1000)]
+    )
+    def test_attributes_return_for_key_value_if_key_present(
+        self, key, expected, minimal_yaml_dict
+    ):
+        minimal_yaml_dict["settings"] = {"services": {"udc": {"token": {key: expected}}}}
+        config = UDCTokenSettings(minimal_yaml_dict)
+        MISSING = object()
+        assert getattr(config, key, MISSING) == expected
+
+    @pytest.mark.parametrize(
+        "key, expected", argvalues=[("deposit", False), ("node_balance", 5000)]
+    )
+    def test_attributes_whose_key_is_absent_return_expected_default(
+        self, key, expected, minimal_yaml_dict
+    ):
+        config = UDCTokenSettings(minimal_yaml_dict)
         MISSING = object()
         assert getattr(config, key, MISSING) == expected


### PR DESCRIPTION
Implements feature as requested per #218 :

2 new keys are available in the `udc` section of the yaml file:

```yaml
settings:
  services:
    udc:
      deposit: true
      # The number of RDN/UDC Tokens required by each node
      balance_per_node: 5000
      # The maximum funding amount to deposit - defaults to `balance_per_node` if not given.
      max_funding: 5000
```