### PR TITLE
Refactor commit message validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,8 +173,8 @@ jobs:
   prep-system:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - checkout
+      - skip_bad_commit_format
       - prep_venv
       - export_env_vars
       - persist_to_workspace:
@@ -187,25 +187,25 @@ jobs:
   test-harness:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
+      - skip_bad_commit_format
       - run_test_harness
 
   syle-check-and-lint:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
+      - skip_bad_commit_format
       - lint_codebase
 
   lint-and-test:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
+      - skip_bad_commit_format
       - lint_codebase
       - run_test_harness
 
@@ -214,9 +214,9 @@ jobs:
   bump-versions:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
+      - skip_bad_commit_format
       - export_env_vars
       - run:
           name: Add Github to known hosts.
@@ -241,8 +241,8 @@ jobs:
   deploy-to-pypi:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - checkout
+      - skip_bad_commit_format
       - run:
           name: Publish to pypi using flit.
           command: |
@@ -253,13 +253,11 @@ jobs:
   tear-down:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - store_env
 
   finalize:
     executor: default-executor
     steps:
-      - skip_bad_commit_format
       - run: echo "done".
 
 ################################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,6 @@ PR_branches_only: &PR_branches_only
       ignore:
         - /^\d+\.\d+.*/
 
-steps_for_valid_commits: &steps_for_valid_commits
-  steps:
-    - run:
-        command: skip_bad_commit_format
-
 ################################################################################
 #                                                                              #
 # Custom Executor definitions.                                                 #
@@ -175,17 +170,10 @@ commands:
 
 jobs:
 
-  validate-commit-message:
-    executor: default-executor
-    *steps_for_valid_commits:
-      - attach_workspace:
-          at: "/home/circleci"
-      - export_env_vars
-      - skip_bad_commit_format
-
   prep-system:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
       - checkout
       - prep_venv
       - export_env_vars
@@ -198,14 +186,24 @@ jobs:
   # our code base.
   test-harness:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
       - run_test_harness
 
   syle-check-and-lint:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
+      - attach_workspace:
+          at: "/home/circleci"
+      - lint_codebase
+
+  lint-and-test:
+    executor: default-executor
+    steps:
+      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
       - lint_codebase
@@ -215,7 +213,8 @@ jobs:
   # release type to the version.
   bump-versions:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
       - attach_workspace:
           at: "/home/circleci"
       - export_env_vars
@@ -241,7 +240,8 @@ jobs:
   # Publish a wheel and tarball of the Scenario Player to pypi.
   deploy-to-pypi:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
       - checkout
       - run:
           name: Publish to pypi using flit.
@@ -252,12 +252,14 @@ jobs:
 
   tear-down:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
       - store_env
 
   finalize:
     executor: default-executor
-    *steps_for_valid_commits:
+    steps:
+      - skip_bad_commit_format
       - run: echo "done".
 
 ################################################################################
@@ -319,7 +321,6 @@ workflows:
       - finalize:
           requires:
             - prep-system
-            - validate-commit-message
             - lint-and-test
             - bump-versions
             - tear-down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,17 @@ commands:
   # CI Setup Commands #
   # ================= #
 
+  setup-job:
+    description: |
+      Attach the workspace and load ENV variables.
+      Additionally skips the job this is used in, if the commit message is invalid
+      (unless the workflow executing the job is running on "master" or "dev").
+    steps:
+      - attach_workspace:
+          at: "/home/circleci"
+      - export_env_vars
+      - skip_bad_commit_format
+
   export_env_vars:
     description: Export ENV variables used by our script.
     steps:
@@ -174,9 +185,9 @@ jobs:
     executor: default-executor
     steps:
       - checkout
-      - skip_bad_commit_format
       - prep_venv
       - export_env_vars
+      - skip_bad_commit_format
       - persist_to_workspace:
           paths:
             - ci
@@ -187,25 +198,19 @@ jobs:
   test-harness:
     executor: default-executor
     steps:
-      - attach_workspace:
-          at: "/home/circleci"
-      - skip_bad_commit_format
+      - setup-job
       - run_test_harness
 
   syle-check-and-lint:
     executor: default-executor
     steps:
-      - attach_workspace:
-          at: "/home/circleci"
-      - skip_bad_commit_format
+      - setup-job
       - lint_codebase
 
   lint-and-test:
     executor: default-executor
     steps:
-      - attach_workspace:
-          at: "/home/circleci"
-      - skip_bad_commit_format
+      - setup-job
       - lint_codebase
       - run_test_harness
 
@@ -214,10 +219,7 @@ jobs:
   bump-versions:
     executor: default-executor
     steps:
-      - attach_workspace:
-          at: "/home/circleci"
-      - skip_bad_commit_format
-      - export_env_vars
+      - setup-job
       - run:
           name: Add Github to known hosts.
           command: |
@@ -242,6 +244,7 @@ jobs:
     executor: default-executor
     steps:
       - checkout
+      - export_env_vars
       - skip_bad_commit_format
       - run:
           name: Publish to pypi using flit.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,10 @@ PR_branches_only: &PR_branches_only
       ignore:
         - /^\d+\.\d+.*/
 
+steps_for_valid_commits: &steps_for_valid_commits
+  steps:
+    - run:
+        command: skip_bad_commit_format
 
 ################################################################################
 #                                                                              #
@@ -114,7 +118,7 @@ commands:
             make install-dev
 
 
-  validate_commit_format:
+  skip_bad_commit_format:
     description: Validate the first line of the commit message against a REGEX.
     steps:
       - run:
@@ -173,15 +177,15 @@ jobs:
 
   validate-commit-message:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
       - attach_workspace:
           at: "/home/circleci"
       - export_env_vars
-      - validate_commit_format
+      - skip_bad_commit_format
 
   prep-system:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
       - checkout
       - prep_venv
       - export_env_vars
@@ -192,9 +196,16 @@ jobs:
 
   # Run all test suites (aka the test harness) of the repository and lint-check
   # our code base.
-  lint-and-test:
+  test-harness:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
+      - attach_workspace:
+          at: "/home/circleci"
+      - run_test_harness
+
+  syle-check-and-lint:
+    executor: default-executor
+    *steps_for_valid_commits:
       - attach_workspace:
           at: "/home/circleci"
       - lint_codebase
@@ -204,7 +215,7 @@ jobs:
   # release type to the version.
   bump-versions:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
       - attach_workspace:
           at: "/home/circleci"
       - export_env_vars
@@ -230,7 +241,7 @@ jobs:
   # Publish a wheel and tarball of the Scenario Player to pypi.
   deploy-to-pypi:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
       - checkout
       - run:
           name: Publish to pypi using flit.
@@ -241,12 +252,12 @@ jobs:
 
   tear-down:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
       - store_env
 
   finalize:
     executor: default-executor
-    steps:
+    *steps_for_valid_commits:
       - run: echo "done".
 
 ################################################################################
@@ -263,7 +274,12 @@ workflows:
       - prep-system:
           <<: *PR_branches_only
 
-      - lint-and-test:
+      - test-harness:
+          context: Raiden-SP-Context
+          requires:
+            - prep-system
+
+      - syle-check-and-lint:
           context: Raiden-SP-Context
           requires:
             - prep-system
@@ -271,23 +287,19 @@ workflows:
       - finalize:
           requires:
             - prep-system
-            - lint-and-test
+            - syle-check-and-lint
+            - test-harness
 
   Merge-Commit-Workflow:
     jobs:
       - prep-system:
           <<: *master_dev_only
 
-      - validate-commit-message:
-          context: Raiden-SP-Context
-          requires:
-            - prep-system
-
       # Run linters and test harnesses against PR branches.
       - lint-and-test:
           context: Raiden-SP-Context
           requires:
-            - validate-commit-message
+            - prep-system
 
       # Bump the minor or patch for `master` on each merge commit.
       - bump-versions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ commands:
     steps:
       - run:
           name: Validate the commit's title description.
-          command: python3 ${CI_SCRIPTS_DIR}/validate-commit-message.py
+          command: python3 ${CI_SCRIPTS_DIR}/skip-on-bad-commit-message.py
 
   # ================================== #
   # Linter and test execution commands #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,6 @@ jobs:
       - checkout
       - prep_venv
       - export_env_vars
-      - skip_bad_commit_format
       - persist_to_workspace:
           paths:
             - ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       - setup-job
       - run_test_harness
 
-  syle-check-and-lint:
+  style-check-and-lint:
     executor: default-executor
     steps:
       - setup-job
@@ -282,7 +282,7 @@ workflows:
           requires:
             - prep-system
 
-      - syle-check-and-lint:
+      - style-check-and-lint:
           context: Raiden-SP-Context
           requires:
             - prep-system
@@ -290,7 +290,7 @@ workflows:
       - finalize:
           requires:
             - prep-system
-            - syle-check-and-lint
+            - style-check-and-lint
             - test-harness
 
   Merge-Commit-Workflow:

--- a/.circleci/scripts/skip-on-bad-commit-message.py
+++ b/.circleci/scripts/skip-on-bad-commit-message.py
@@ -4,4 +4,4 @@ try:
     subprocess.run("python ${CI_SCRIPTS_DIR}/validate-commit-message.py".split(), check=True)
 except subprocess.SubprocessError:
     # The commit message is bogus, so we skip the current step.
-    subprocess.run("circle step halt".split())
+    subprocess.run("circleci step halt".split())

--- a/.circleci/scripts/skip-on-bad-commit-message.py
+++ b/.circleci/scripts/skip-on-bad-commit-message.py
@@ -1,0 +1,7 @@
+import subprocess
+
+try:
+    subprocess.run("python validate-commit-message.py".split(), check=True)
+except subprocess.SubprocessError:
+    # The commit message is bogus, so we skip the current step.
+    subprocess.run("circle step halt".split())

--- a/.circleci/scripts/skip-on-bad-commit-message.py
+++ b/.circleci/scripts/skip-on-bad-commit-message.py
@@ -1,7 +1,7 @@
 import subprocess
 
 try:
-    subprocess.run("python validate-commit-message.py".split(), check=True)
+    subprocess.run("python ${CI_SCRIPTS_DIR}/validate-commit-message.py".split(), check=True)
 except subprocess.SubprocessError:
     # The commit message is bogus, so we skip the current step.
     subprocess.run("circle step halt".split())

--- a/.circleci/scripts/validate-commit-message.py
+++ b/.circleci/scripts/validate-commit-message.py
@@ -6,6 +6,10 @@ from constants import COMMIT_MSG, COMMIT_TYPE, CURRENT_BRANCH
 print(f"Validating commit message {COMMIT_MSG!r}")
 print(f"Parsed commit type: {COMMIT_TYPE}")
 
+if CURRENT_BRANCH not in ("master", "dev"):
+    # This workflow is executed on a PR - we skip validation for these.
+    exit(0)
+
 if not COMMIT_TYPE:
     # The commit message title does not comply with any of our regexes.
     print("No commit type parsed - the commit message does not comply with the required pattern!")


### PR DESCRIPTION
now skips all steps instead of failing.
Does not validate commit messages of commits pushed to a PR branch.