### PR TITLE
Incorporate changes of #238 into test fixtures.

### DIFF
--- a/scenario_player/constants.py
+++ b/scenario_player/constants.py
@@ -5,8 +5,8 @@ from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_p
 #: The namespace plugins should use as a prefix when creating a :class:`pluggy.HookimplMarker`.
 HOST_NAMESPACE = "scenario_player"
 
-DEFAULT_TOKEN_BALANCE_MIN = 2_000
-DEFAULT_TOKEN_BALANCE_FUND = 10_000
+DEFAULT_TOKEN_BALANCE_MIN = 5_000
+DEFAULT_TOKEN_BALANCE_FUND = 50_000
 OWN_ACCOUNT_BALANCE_MIN = 5 * 10 ** 17  # := 0.5 Eth
 NODE_ACCOUNT_BALANCE_MIN = 15 * 10 ** 16  # := 0.15 Eth
 NODE_ACCOUNT_BALANCE_FUND = 3 * 10 ** 17  # := 0.3 Eth

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -42,26 +42,54 @@ class PFSSettingsConfig(ConfigMapping):
 
 
 class UDCTokenSettings(ConfigMapping):
+    """UDC Token Settings Interface.
+
+    Example scenario yaml::
+
+        >my_scenario.yaml
+          ---
+            udc:
+              ...
+              token:
+                deposit: false
+                balance_per_node: 5000
+                max_funding: 5000
+            ...
+    """
+
+    CONFIGURATION_ERROR = UDCTokenConfigError
+
     def __init__(self, loaded_yaml: dict):
         udc_settings = ((loaded_yaml.get("settings") or {}).get("services") or {}).get("udc") or {}
         super(UDCTokenSettings, self).__init__(udc_settings.get("token"))
         self.validate()
-        print(self.dict)
 
-    def validate(self):
-        self.assert_option(self.max_funding >= self.balance_per_node, UDCTokenConfigError)
+    def validate(self) -> None:
+        """Validate the UDC Token options given.
+
+        :raises UDCTokenConfigError: if :attr:`.max_funding` < :attr:`.balance_per_node`.
+        """
+        self.assert_option(
+            self.max_funding >= self.balance_per_node,
+            "udc.token.max_funding must be >= udc.token.balance_per_node!",
+        )
 
     @property
-    def deposit(self):
+    def deposit(self) -> bool:
+        """Whether or not to deposit tokens at nodes.
+
+        If this is set to False or not given, the attributes :attr:`.max_funding` and
+        :attr:`.balance_per_node` will not be used.
+        """
         return self.get("deposit", False)
 
     @property
-    def balance_per_node(self):
+    def balance_per_node(self) -> int:
         """The required amount of UDC/RDN tokens required by each node."""
         return int(self.get("balance_per_node", 5000))
 
     @property
-    def max_funding(self):
+    def max_funding(self) -> int:
         """The maximum amount to fund when depositing RDN tokens at a target.
 
         It defaults to :attr:`.balance_per_node`'s value.
@@ -80,13 +108,11 @@ class UDCSettingsConfig(ConfigMapping):
         settings:
           ...
           services:
-            ...
             udc:
               enable: True
               address: 0x1000001
               token:
-                deposit: True
-                balance_per_node: 5000
+                <UDCTokenSettings>
             ...
     """
 
@@ -97,11 +123,11 @@ class UDCSettingsConfig(ConfigMapping):
         self.token = UDCTokenSettings(loaded_yaml)
 
     @property
-    def enable(self):
+    def enable(self) -> bool:
         return self.get("enable", False)
 
     @property
-    def address(self):
+    def address(self) -> Union[str, None]:
         return self.get("address")
 
 

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -35,6 +35,10 @@ class DummyRPCConfig:
 
 
 class DummyServicesConfig:
+    pass
+
+
+class DummySPaaSConfig:
     def __init__(self):
         self.rpc = DummyRPCConfig()
 
@@ -43,6 +47,7 @@ class DummySettingsConfig:
     def __init__(self):
         self.timeout = 2
         self.services = DummyServicesConfig()
+        self.spaas = DummySPaaSConfig()
 
 
 class DummyTokenConfig:

--- a/tests/unittests/utils/test_token.py
+++ b/tests/unittests/utils/test_token.py
@@ -532,8 +532,9 @@ class TestUserDepositContract:
         mock_transact.assert_called_once_with("allowance", expected_params)
 
     @patch("scenario_player.utils.token.Contract.transact")
+    @patch("scenario_player.utils.token.UserDepositContract.total_deposit")
     def test_deposit_method_issues_deposit_request_if_node_funding_is_insufficient(
-        self, mock_transact
+        self, mock_total_deposit, mock_transact
     ):
         """deposit() deposits the correct amount of UDC Tokens at the target node's address.
 
@@ -542,9 +543,11 @@ class TestUserDepositContract:
         self.instance.config.settings.services.udc.token.dict["balance_per_node"] = 5_000
         self.instance.config.settings.services.udc.token.dict["max_funding"] = 10_000
         self.mock_effective_balance.return_value = 1000
+        # Set the total_deposit return value ot 1, so we know it was factored in.
+        mock_total_deposit.return_value = 1
 
-        # amount = max_funding - effective_balance
-        expected_params = {"amount": 9_000, "target_address": "some_address"}
+        # amount = total_deposit + max_funding - effective_balance
+        expected_params = {"amount": 9_001, "target_address": "some_address"}
 
         self.instance.deposit("some_address")
 


### PR DESCRIPTION
We also had to update the min balance and max funding constants for custom tokens, as those would otherwise trigger an exception when using all default values.
