### PR TITLE
Fix UDTC allowance calculation

### DIFF
--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -337,6 +337,7 @@ class ScenarioRunner:
             for address, balance in balance_per_node.items()
             if balance < NODE_ACCOUNT_BALANCE_MIN
         }
+        log.debug("Node eth balances", balances=balance_per_node, low_balances=low_balances)
         if low_balances:
             log.info("Funding nodes", nodes=low_balances.keys())
             fund_tx = set()

--- a/scenario_player/services/rpc/blueprints/tokens.py
+++ b/scenario_player/services/rpc/blueprints/tokens.py
@@ -208,7 +208,7 @@ def transact_call(key, data):
 
     contract_proxy = rpc_client.new_contract_proxy(contract_abi, data["contract_address"])
 
-    log.debug("Transacting..", **data)
+    log.debug("Transacting..", action=action, **data)
 
     args = data["amount"], data["target_address"]
     if action != "mintFor":

--- a/scenario_player/services/rpc/blueprints/transactions.py
+++ b/scenario_player/services/rpc/blueprints/transactions.py
@@ -12,9 +12,13 @@ The following endpoints are supplied by this blueprint:
 
 """
 from flask import Blueprint, request
+from structlog import get_logger
 
 from scenario_player.services.common.metrics import REDMetricsTracker
 from scenario_player.services.rpc.schemas.transactions import SendTransactionSchema
+
+log = get_logger(__name__)
+
 
 transactions_blueprint = Blueprint("transactions_view", __name__)
 
@@ -77,6 +81,7 @@ def new_transaction():
     data = transaction_send_schema.validate_and_deserialize(request.get_json())
     rpc_client, _ = data.pop("client"), data.pop("client_id")
 
+    log.debug("Performing transaction", params=data)
     result = rpc_client.send_transaction(**data)
 
     return transaction_send_schema.jsonify({"tx_hash": result})


### PR DESCRIPTION
The UDTC allowance was calculated as a delta of required - current balance, but the `approve` call expects an absolute value. 
This lead to insufficient balance on the last `deposit` call.

Fixes: #238