### PR TITLE
Misc fixes

### DIFF
--- a/scenario_player/services/rpc/utils.py
+++ b/scenario_player/services/rpc/utils.py
@@ -36,7 +36,10 @@ def generate_hash_key(chain_url: str, privkey: bytes, strategy: Callable):
 class RPCClient(JSONRPCClient):
     def __init__(self, chain_url, privkey, strategy):
         super(RPCClient, self).__init__(
-            Web3(HTTPProvider(chain_url)), privkey=privkey, gas_price_strategy=strategy
+            Web3(HTTPProvider(chain_url)),
+            privkey=privkey,
+            gas_price_strategy=strategy,
+            block_num_confirmations=5,
         )
         self.client_id = generate_hash_key(chain_url, privkey, strategy)
 

--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import structlog
 from eth_utils import decode_hex, to_checksum_address
@@ -395,7 +395,7 @@ class UserDepositContract(Contract):
             **kwargs,
         )
 
-    def update_allowance(self) -> Union[Tuple[str, int], None]:
+    def update_allowance(self) -> Tuple[Optional[str], int]:
         """Update the UD Token Contract allowance depending on the number of configured nodes.
 
         If the UD Token Contract's allowance is sufficient, this is a no-op.
@@ -414,7 +414,7 @@ class UserDepositContract(Contract):
 
         if not udt_allowance < required_allowance:
             log.debug("UDTC allowance sufficient")
-            return
+            return None, required_allowance
 
         log.debug("UDTC allowance insufficient, updating")
         params = {


### PR DESCRIPTION
- Fix broken return value in `update_allowance()` introduced by #278
- `reclaim_eth` command:
  - Make it aware of `node_{run_number}_{node_index>}` style node directories
  - Decode keyfiles only on demand to shorten startup time
- Enable 5 confirmation blocks in transaction service `JSONRPCClient`s