### PR TITLE
[FIX-#277] Make node keys unique

### DIFF
--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -355,9 +355,13 @@ class NodeRunner:
         if not keystore_file.exists():
             log.debug("Initializing keystore", node=self._index)
             gevent.sleep()
-            privkey = hashlib.sha256(
-                f"{self._runner.yaml.name}-{self._runner.run_number}-{self._index}".encode()
-            ).digest()
+            seed = (
+                f"{self._runner.local_seed}"
+                f"-{self._runner.yaml.name}"
+                f"-{self._runner.run_number}"
+                f"-{self._index}"
+            ).encode()
+            privkey = hashlib.sha256(seed).digest()
             keystore_file.write_text(json.dumps(create_keyfile_json(privkey, b"")))
         return keystore_file
 

--- a/tests/unittests/test_runner.py
+++ b/tests/unittests/test_runner.py
@@ -96,3 +96,16 @@ class TestScenarioRunner:
                 # Should have raised the TypeError, all good.
                 return
             pytest.fail(f"DID RAISE {e!r}")
+
+
+def test_runner_local_seed(runner, tmp_path):
+    """Ensure the ``.local_seed`` property creates the seed file inside the ``.base_path``."""
+    runner.base_path = tmp_path
+    seed_file = tmp_path.joinpath("seed.txt")
+
+    assert not seed_file.exists()
+
+    runner_seed = runner.local_seed
+
+    assert seed_file.exists()
+    assert runner_seed == seed_file.read_text().strip()


### PR DESCRIPTION
Ensures node keys are unique between multiple users of the scenario
player by using a per-installation (rather per data-dir) seed value.

Fixes: #277