### PR TITLE
Fix typevar in datastructure module

### DIFF
--- a/scenario_player/utils/datastructures.py
+++ b/scenario_player/utils/datastructures.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import _T, Any, Callable, Iterable, Iterator, List, NoReturn, Optional, Union
+from typing import Any, Callable, Generic, Iterable, List, NoReturn, Optional, TypeVar, Union
+
+T = TypeVar("T")
 
 
-class FrozenList(list):
+class FrozenList(list, Generic[T]):
     """An immutable list."""
 
     def _not_supported(self) -> NoReturn:
@@ -15,55 +17,52 @@ class FrozenList(list):
     def __delitem__(self, i: Union[int, slice]) -> NoReturn:
         self._not_supported()
 
-    def __iadd__(self, x: Iterable[_T]) -> NoReturn:
+    def __iadd__(self, x: Iterable[T]) -> NoReturn:
         self._not_supported()
 
     def __imul__(self, n: int) -> NoReturn:
         self._not_supported()
 
-    def append(self, obj: _T) -> NoReturn:
+    def append(self, obj: T) -> NoReturn:  # pylint: disable=unused-argument
         self._not_supported()
 
     def clear(self) -> NoReturn:
         self._not_supported()
 
-    def extend(self, iterable: Iterable[_T]) -> NoReturn:
+    def extend(self, iterable: Iterable[T]) -> NoReturn:  # pylint: disable=unused-argument
         self._not_supported()
 
-    def insert(self, index: int, object: _T) -> NoReturn:
+    def insert(self, index: int, item: T) -> NoReturn:  # pylint: disable=unused-argument
         self._not_supported()
 
-    def pop(self, index: int = 0) -> NoReturn:
+    def pop(self, index: int = 0) -> NoReturn:  # pylint: disable=unused-argument
         self._not_supported()
 
-    def remove(self, obj: _T) -> NoReturn:
+    def remove(self, obj: T) -> NoReturn:  # pylint: disable=unused-argument
         self._not_supported()
 
     def reverse(self) -> NoReturn:
         self._not_supported()
 
-    def sort(
-        self, *, key: Optional[Callable[[_T], Any]] = None, reverse: bool = False
+    def sort(  # pylint: disable=unused-argument
+        self, *, key: Optional[Callable[[T], Any]] = None, reverse: bool = False
     ) -> NoReturn:
         self._not_supported()
 
     def __hash__(self) -> int:
         return hash(repr(self))
 
-    def __add__(self, x: List[_T]) -> FrozenList[_T]:
+    def __add__(self, x: List[T]) -> FrozenList[T]:
         return self.__class__(super().__add__(x))
 
-    def __mul__(self, n: int) -> FrozenList[_T]:
+    def __mul__(self, n: int) -> FrozenList[T]:
         return self.__class__(super().__mul__(n))
 
-    def __rmul__(self, n: int) -> FrozenList[_T]:
+    def __rmul__(self, n: int) -> FrozenList[T]:
         return self.__class__(super().__rmul__(n))
-
-    def __reversed__(self) -> Iterator[_T]:
-        return self.__class__(super().__reversed__())
 
     def __repr__(self) -> str:
         return f"<FrozenList({super().__repr__()})>"
 
-    def copy(self) -> List[_T]:
+    def copy(self) -> List[T]:
         return self


### PR DESCRIPTION
    Fixed FrozenList typing

    This defines a TypeVar in the datastructures module instead of trying to
    import it form the standard library typing module. It also renamed the
    variables that shadowed the built-in `object`, disabled the pylint
    false-positives, and fixed the `__reversed__` implementation.