### PR TITLE
Wait for all nodes when checking Token Network Discovery

### DIFF
--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -74,6 +74,7 @@ class DummyScenarioYAML:
 class DummyNodeRunner:
     def __init__(self, index):
         self.index = index
+        self.base_url = index
 
     @property
     def address(self):

--- a/tests/unittests/test_runner.py
+++ b/tests/unittests/test_runner.py
@@ -97,6 +97,16 @@ class TestScenarioRunner:
                 return
             pytest.fail(f"DID RAISE {e!r}")
 
+    @mock.patch("scenario_player.runner.ScenarioRunner.wait_for_token_network_discovery")
+    def test_ensure_token_network_discovery_checks_all_nodes_for_discovery(self, mock_wait_for_token_network_discovery, _, runner):
+        """All nodes must have discovered the token network - make sure it checks
+        all of them accordingly."""
+        runner.node_controller = [mock.MagicMock(base_url="node1"), mock.MagicMock(base_url="node2"), mock.MagicMock(base_url="node3")]
+        runner.ensure_token_network_discovery()
+
+        for node in runner.node_controller:
+            mock_wait_for_token_network_discovery.assert_any_call(node.base_url)
+
 
 def test_runner_local_seed(runner, tmp_path):
     """Ensure the ``.local_seed`` property creates the seed file inside the ``.base_path``."""


### PR DESCRIPTION
Previously, we only checked the last node for
the token network discovery. This is prone
to race conditions, and should be avoided by
checking with all nodes instead.

Fixes #132 , also #324 