### PR TITLE
Increase maximum tokens minted

### DIFF
--- a/scenario_player/constants.py
+++ b/scenario_player/constants.py
@@ -6,7 +6,7 @@ from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_p
 HOST_NAMESPACE = "scenario_player"
 
 DEFAULT_TOKEN_BALANCE_MIN = 5_000
-DEFAULT_TOKEN_BALANCE_FUND = 50_000
+DEFAULT_TOKEN_BALANCE_FUND = 1_000_000
 OWN_ACCOUNT_BALANCE_MIN = 5 * 10 ** 17  # := 0.5 Eth
 NODE_ACCOUNT_BALANCE_MIN = 15 * 10 ** 16  # := 0.15 Eth
 NODE_ACCOUNT_BALANCE_FUND = 3 * 10 ** 17  # := 0.3 Eth


### PR DESCRIPTION
Some scenarios require higher token amounts to be deposited in order to make the fee calculations easier. This PR allows for that.