### PR TITLE
Allow chain URLs without TLD

### DIFF
--- a/scenario_player/services/rpc/schemas/instances.py
+++ b/scenario_player/services/rpc/schemas/instances.py
@@ -33,7 +33,7 @@ class CreateClientSchema(SPSchema):
     """
 
     # Deserialization fields.
-    chain_url = Url(required=True, load_only=True)
+    chain_url = Url(required=True, load_only=True, require_tld=False)
     privkey = BytesField(required=True, load_only=True)
     gas_price = GasPrice(required=False, load_only=True, missing="FAST")
 


### PR DESCRIPTION
This is useful e.g. in a docker setup where a inter-container URL usually has no TLD.