### PR TITLE
Accept a reveal timeout param for open channel task

### DIFF
--- a/scenario_player/tasks/channels.py
+++ b/scenario_player/tasks/channels.py
@@ -36,6 +36,9 @@ class OpenChannelTask(RaidenAPIActionTask):
         settle_timeout = self._config.get("settle_timeout")
         if settle_timeout is not None:
             params["settle_timeout"] = settle_timeout
+        reveal_timeout = self._config.get("reveal_timeout")
+        if reveal_timeout is not None:
+            params["reveal_timeout"] = reveal_timeout
         return params
 
 


### PR DESCRIPTION
In https://github.com/raiden-network/raiden/pull/4999 i introduce a new parameter `reveal_timeout` in the `PATCH` channel endpoint. This PR enables the `OpenChannelTask` to accept this new parameter.

NOTE: Do **not** merge until the above PR is merged.