### PR TITLE
Add lock timeout parameter

### DIFF
--- a/scenario_player/tasks/channels.py
+++ b/scenario_player/tasks/channels.py
@@ -113,6 +113,9 @@ class TransferTask(ChannelActionTask):
         params = dict(amount=self._config["amount"])
         if "identifier" in self._config:
             params["identifier"] = self._config["identifier"]
+        if "lock_timeout" in self._config:
+            params["lock_timeout"] = self._config["lock_timeout"]
+
         return params
 
 

--- a/tests/unittests/tasks/test_channels.py
+++ b/tests/unittests/tasks/test_channels.py
@@ -4,7 +4,6 @@ import json
 
 import pytest
 from tests.unittests.constants import NODE_ADDRESS_0, NODE_ADDRESS_1, TEST_TOKEN_ADDRESS
-
 # TODO: Add tests for request timeouts
 from tests.unittests.tasks.utils import generic_task_test
 
@@ -229,6 +228,18 @@ from scenario_player.tasks.channels import STORAGE_KEY_CHANNEL_INFO
             200,
             {"resp": 1},
             id="transfer-id-given",
+        ),
+        pytest.param(
+            "transfer",
+            {"from": 0, "to": 1, "amount": 1, "identifier": 1, "lock_timeout": 30},
+            None,
+            None,
+            "POST",
+            f"http://0/api/v1/payments/{TEST_TOKEN_ADDRESS}/{NODE_ADDRESS_1}",
+            {"amount": 1, "identifier": 1, "lock_timeout": 30},
+            200,
+            {"resp": 1},
+            id="transfer-lock-timeout-given",
         ),
         pytest.param(
             "assert",


### PR DESCRIPTION
This is required if there is a possibility to adjust the channel's `settle_timeout` and `reveal_timeout`. The lock_timeout has to be smaller than the channel's settle timeout.