### PR TITLE
Replace undefined DEVELOPMENT_CONTRACT_VERSION

### DIFF
--- a/scenario_player/tasks/blockchain.py
+++ b/scenario_player/tasks/blockchain.py
@@ -110,7 +110,7 @@ class AssertBlockchainEventsTask(Task):
         # get the correct contract address
         # this has to be done in `_run`, otherwise `_runner` is not initialized yet
         contract_data = get_contracts_deployment_info(
-            chain_id=self._runner.chain_id, version=DEVELOPMENT_CONTRACT_VERSION
+            chain_id=self._runner.chain_id, version=RAIDEN_CONTRACT_VERSION
         )
         if self.contract_name == CONTRACT_TOKEN_NETWORK:
             self.contract_address = self._runner.token_network_address
@@ -165,7 +165,7 @@ class AssertMSClaimTask(Task):
 
         # get the MS contract address
         contract_data = get_contracts_deployment_info(
-            chain_id=self._runner.chain_id, version=DEVELOPMENT_CONTRACT_VERSION
+            chain_id=self._runner.chain_id, version=RAIDEN_CONTRACT_VERSION
         )
         try:
             contract_info = contract_data["contracts"][self.contract_name]


### PR DESCRIPTION
In this file, the symbol DEVELOPMENT_CONTRACT_VERSION is no longer available.  Only `RAIDEN_CONTRACT_VERSION` is [available](https://github.com/raiden-network/scenario-player/blob/7b64540a050b1e351c9c4dab78ca021bbaae583d/scenario_player/tasks/blockchain.py#L17).

So instead of `DEVELOPMENT_CONTRACT_VERSION`, this PR uses `RAIDEN_CONTRACT_VERSION`.

Originally, `DEVELOPMENT_CONTRACT_VERSION` and `PRODUCTION_CONTRACT_VERSION` were merged into `RAIDEN_CONTRACT_VERSION` here:
https://github.com/raiden-network/raiden/commit/7a91946dee34c2ac6c68c2fc500d51d7b57108b1
