### PR TITLE
Employ Docker Hub Build Hooks

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -71,6 +71,7 @@ WORKDIR /
 # Copy virtual env and scenario definition files.
 COPY --from=compile-image /opt/venv /opt/venv
 COPY --from=compile-image /scenarios /scenarios
+COPY --from=compile-image /logs/build.log /build.log
 ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /scenarios

--- a/.docker/post_build
+++ b/.docker/post_build
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# The default behaviour of the Dockerfile is to build the SP master
+# branch against raiden and the scenarios from the develop branch, which
+# is then tagged as `latest` and pushed to the scenario-player docker hub.
+#
+# This post build hook builds 4 further tags:
+#
+# - raiden develop / scenarios develop (identical to `scenario-player:latest`)
+# - raiden develop / scenarios stable
+# - raiden stable / scenarios stable
+# - raiden stable / scenarios develop
+
+docker build . -t raiden_stable-scenarios_stable --build-arg RAIDEN_VERSION=master --build-arg SCENARIOS_VERSION=master
+docker build . -t raiden_develop-scenarios_stable --build-arg RAIDEN_VERSION=develop --build-arg SCENARIOS_VERSION=master
+docker build . -t raiden_stable-scenarios_develop --build-arg RAIDEN_VERSION=master --build-arg SCENARIOS_VERSION=develop
+docker build . -t raiden_develop-scenarios_develop --build-arg RAIDEN_VERSION=develop --build-arg SCENARIOS_VERSION=develop

--- a/.docker/post_push
+++ b/.docker/post_push
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker push raidennetwork/scenario-player:raiden_stable-scenarios_stable
+docker push raidennetwork/scenario-player:raiden_develop-scenarios_stable
+docker push raidennetwork/scenario-player:raiden_stable-scenarios_develop
+docker push raidennetwork/scenario-player:raiden_develop-scenarios_develop


### PR DESCRIPTION
Makes use of Docker Hub build hooks to build
and push additional tags, which would otherwise
require passing build args via CI or manually.

The resulting images are mostly a convenience,
as they can easily be built locally by
passing the relevant build args. However, since
docker hub offers to do the work for us, we might as
well make use of that.