### PR TITLE
Support unknown flags and options

### DIFF
--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -72,6 +72,7 @@ MANAGED_CONFIG_OPTIONS_OVERRIDABLE = {
 
 KNOWN_OPTIONS = {param.name.replace("_", "-") for param in cli_run.params}
 FLAG_OPTIONS = {param.name.replace("_", "-") for param in cli_run.params if param.is_flag}
+FLAG_OPTIONS += {'no-' + opt for opt in FLAG_OPTIONS}
 
 
 class NodeState(Enum):
@@ -318,7 +319,10 @@ class NodeRunner:
         if pfs_address:
             cmd.extend(["--pathfinding-service-address", pfs_address])
 
+        seen = set()
+
         for option_name in MANAGED_CONFIG_OPTIONS_OVERRIDABLE:
+            seen.add(option_name)
             if option_name in ("api-address", "pathfinding-service-address"):
                 # already handled above
                 continue
@@ -333,6 +337,7 @@ class NodeRunner:
             KNOWN_OPTIONS - MANAGED_CONFIG_OPTIONS - MANAGED_CONFIG_OPTIONS_OVERRIDABLE
         )
         for option_name in remaining_option_candidates:
+            seen.add(option_name)
             if option_name in self._options:
                 if option_name not in FLAG_OPTIONS:
                     option_value = self._options[option_name]


### PR DESCRIPTION
This should no longer limit the CLI options supported by the SP.

Flags which are not present in `FLAG_OPTIONS` can be passed by setting their value to a `True` or `False`
```yaml
nodes:
  default-options:
    this_is_a_flag_option: true
    address: 1234
```

Results in the raiden client being run like so
```bash
raiden --this_is_a_flag_option --address 1234 [...]
```

Since this is a cherry-pick I'm not including tests, those will be merged once the refac Pr (from which this stems) is done.