### PR TITLE
Allow to assert with given error margin

### DIFF
--- a/scenario_player/tasks/channels.py
+++ b/scenario_player/tasks/channels.py
@@ -153,7 +153,17 @@ class AssertTask(ChannelActionTask):
                 raise ScenarioAssertionError(
                     f'Field "{field}" is missing in channel: {response_dict}'
                 )
-            if response_dict[field] != self._config[field]:
+            allow_error = self._config.get("allow_" + field + "_error")
+            if allow_error:
+                success = (
+                    response_dict[field] - allow_error
+                    <= self._config[field]
+                    <= response_dict[field] + allow_error
+                )
+                log.info("allow_error", allow_error=allow_error, error_success=success)
+            else:
+                success = response_dict[field] == self._config[field]
+            if not success:
                 raise ScenarioAssertionError(
                     f'Value mismatch for "{field}". '
                     f'Should: "{self._config[field]}" '

--- a/tests/unittests/tasks/test_channels.py
+++ b/tests/unittests/tasks/test_channels.py
@@ -267,6 +267,18 @@ from scenario_player.tasks.channels import STORAGE_KEY_CHANNEL_INFO
         ),
         pytest.param(
             "assert",
+            {"from": 0, "to": 1, "balance": 100, "allow_balance_error": 1},
+            None,
+            None,
+            "GET",
+            f"http://0/api/v1/channels/{TEST_TOKEN_ADDRESS}/{NODE_ADDRESS_1}",
+            {},
+            200,
+            {"balance": 101},
+            id="assert-balance-with-allowed-error",
+        ),
+        pytest.param(
+            "assert",
             {"from": 0, "to": 1, "total_deposit": 100},
             None,
             None,


### PR DESCRIPTION
Some scenarios exhibit cases where the results are not precisely known
due to approximations are floating point inaccuracy. To get reliably
working scenarios, being able to give an acceptable error margin for
those corner cases is required.