### PR TITLE
Add `version` subcommand to cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,20 +44,11 @@ Using  ``git`` & ``pip``::
     # Install the scenario-player.
     ~/ $pip install ./scenario-player
 
+    # Show available commands:
     ~/ $scenario_player --help
-    Usage: scenario_player [OPTIONS] COMMAND [ARGS]...
 
-    Options:
-      --data-path DIRECTORY           [default: $HOME/.raiden/scenario-player]
-      --chain <chain-name>:<eth-node-rpc-url>
-                                      Chain name to eth rpc url mapping, multiple allowed
-                                      [required]
-      --help                          Show this message and exit.
-
-    Commands:
-      pack-logs (experimental)
-      reclaim-eth
-      run
+    # Show help for subcommand, e.g.:
+    ~/ $scenario_player run --help
 
 
 You can also use `make`::
@@ -96,15 +87,14 @@ ways, depending on how you installed the tool.
 
 Invoke the command directly on the cli::
 
-    $ scenario-player --chain=goerli:http://geth.goerli.ethnodes.brainbot.com:8545 \
-
-        run --keystore-file=/path/to/keystore.file --password=${KEYSTORE_PW} \
+    $ scenario-player run --chain=goerli:http://geth.goerli.ethnodes.brainbot.com:8545 \
+        --keystore-file=/path/to/keystore.file --password=${KEYSTORE_PW} \
         /path/to/scenario.yaml
 
 Reclaiming spent test ether::
 
-    $ scenario-player --chain=goerli:http://geth.goerli.ethnodes.brainbot.com:8545 \
-        reclaim-eth --keystore-file=/path/to/keystore.file --password=${KEYSTORE_PW}
+    $ scenario-player reclaim --chain=goerli:http://geth.goerli.ethnodes.brainbot.com:8545 \
+        --keystore-file=/path/to/keystore.file --password=${KEYSTORE_PW}
 
 
 If you're using docker, use the ``docker run`` command, like so::

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 import os
 import sys
@@ -107,47 +108,73 @@ def get_account(keystore_file, password):
     return account
 
 
-@click.group(invoke_without_command=True, context_settings={"max_content_width": 120})
-@click.option(
-    "--data-path",
-    default=str(Path.home().joinpath(".raiden", "scenario-player")),
-    type=click.Path(exists=False, dir_okay=True, file_okay=False),
-    show_default=True,
-)
-@click.option(
-    "--chain",
-    "chains",
-    type=ChainConfigType(),
-    multiple=True,
-    required=True,
-    help="Chain name to eth rpc url mapping, multiple allowed",
-)
-@click.pass_context
-def main(ctx, chains, data_path):
-    gevent.get_hub().exception_stream = DummyStream()
-    chain_rpc_urls = parse_chain_rpc_urls(chains)
+def key_password_options(func):
+    """Decorator for adding '--keystore-file', '--password/--password-file' to subcommands."""
 
-    if ctx.invoked_subcommand:
-        ctx.obj = dict(chain_rpc_urls=chain_rpc_urls, data_path=Path(data_path))
+    @click.option("--keystore-file", required=True, type=click.Path(exists=True, dir_okay=False))
+    @click.option(
+        "--password-file",
+        type=click.Path(exists=True, dir_okay=False),
+        cls=MutuallyExclusiveOption,
+        mutually_exclusive=["password"],
+        default=None,
+    )
+    @click.option(
+        "--password",
+        envvar="ACCOUNT_PASSWORD",
+        cls=MutuallyExclusiveOption,
+        mutually_exclusive=["password-file"],
+        default=None,
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def data_path_option(func):
+    """Decorator for adding '--data-path' to subcommands."""
+
+    @click.option(
+        "--data-path",
+        default=Path(str(Path.home().joinpath(".raiden", "scenario-player"))),
+        type=click.Path(exists=False, dir_okay=True, file_okay=False),
+        show_default=True,
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def chain_option(func):
+    """Decorator for adding '--chain' to subcommands."""
+
+    @click.option(
+        "--chain",
+        "chains",
+        type=ChainConfigType(),
+        multiple=True,
+        required=True,
+        help="Chain name to eth rpc url mapping, multiple allowed",
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@click.group(invoke_without_command=True, context_settings={"max_content_width": 120})
+@click.pass_context
+def main(ctx):
+    gevent.get_hub().exception_stream = DummyStream()
 
 
 @main.command(name="run")
 @click.argument("scenario-file", type=click.File(), required=False)
-@click.option("--keystore-file", required=True, type=click.Path(exists=True, dir_okay=False))
-@click.option(
-    "--password-file",
-    type=click.Path(exists=True, dir_okay=False),
-    cls=MutuallyExclusiveOption,
-    mutually_exclusive=["password"],
-    default=None,
-)
-@click.option(
-    "--password",
-    envvar="ACCOUNT_PASSWORD",
-    cls=MutuallyExclusiveOption,
-    mutually_exclusive=["password-file"],
-    default=None,
-)
 @click.option("--auth", default="")
 @click.option("--mailgun-api-key")
 @click.option(
@@ -162,9 +189,14 @@ def main(ctx, chains, data_path):
     default=sys.stdout.isatty(),
     help="En-/disable console UI. [default: auto-detect]",
 )
+@key_password_options
+@chain_option
+@data_path_option
 @click.pass_context
 def run(
     ctx,
+    chains,
+    data_path,
     mailgun_api_key,
     auth,
     password,
@@ -174,7 +206,7 @@ def run(
     enable_ui,
     password_file,
 ):
-    """Execute a scenario as defined in scenario definiiotn file.
+    """Execute a scenario as defined in scenario definition file.
 
     Calls :func:`exit` when done, with the following status codes:
 
@@ -191,10 +223,9 @@ def run(
         There was an assertion error while executing the scenario. This points
         to an error in a `raiden` component (the client, services or contracts).
     """
-    scenario_file = Path(scenario_file.name).absolute()
-    data_path = ctx.obj["data_path"]
-    chain_rpc_urls = ctx.obj["chain_rpc_urls"]
+    chain_rpc_urls = parse_chain_rpc_urls(chains)
 
+    scenario_file = Path(scenario_file.name).absolute()
     log_file_name = construct_log_file_name("run", data_path, scenario_file)
     configure_logging_for_subcommand(log_file_name)
 
@@ -302,33 +333,20 @@ def run(
 
 
 @main.command(name="reclaim-eth")
-@click.option("--keystore-file", required=True, type=click.Path(exists=True, dir_okay=False))
-@click.option(
-    "--password-file",
-    type=click.Path(exists=True, dir_okay=False),
-    cls=MutuallyExclusiveOption,
-    mutually_exclusive=["password"],
-    default=None,
-)
-@click.option(
-    "--password",
-    envvar="ACCOUNT_PASSWORD",
-    cls=MutuallyExclusiveOption,
-    mutually_exclusive=["password-file"],
-    default=None,
-)
 @click.option(
     "--min-age",
     default=72,
     show_default=True,
     help="Minimum account non-usage age before reclaiming eth. In hours.",
 )
+@key_password_options
+@chain_option
+@data_path_option
 @click.pass_context
-def reclaim_eth(ctx, min_age, password, password_file, keystore_file):
+def reclaim_eth(ctx, min_age, password, password_file, keystore_file, chains, data_path):
     from scenario_player.utils import reclaim_eth
 
-    data_path = ctx.obj["data_path"]
-    chain_rpc_urls = ctx.obj["chain_rpc_urls"]
+    chain_rpc_urls = parse_chain_rpc_urls(chains)
     password = get_password(password, password_file)
     account = get_account(keystore_file, password)
 
@@ -354,9 +372,10 @@ def reclaim_eth(ctx, min_age, password, password_file, keystore_file):
 )
 @click.option("--post-to-rocket/--no-post-to-rocket", default=True)
 @click.argument("scenario-file", type=click.Path(exists=True, dir_okay=False), required=True)
+@data_path_option
 @click.pass_context
-def pack_logs(ctx, scenario_file, post_to_rocket, pack_n_latest, target_dir):
-    data_path: Path = ctx.obj["data_path"].absolute()
+def pack_logs(ctx, scenario_file, data_path, post_to_rocket, pack_n_latest, target_dir):
+    data_path: Path = data_path.absolute()
     scenario_file = Path(scenario_file).absolute()
     target_dir = Path(target_dir)
     scenario_name = scenario_file.stem

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -17,13 +17,15 @@ import gevent
 import requests
 import structlog
 from eth_utils import to_checksum_address
+from raiden_contracts.constants import CONTRACTS_VERSION
 from urwid import ExitMainLoop
 from web3.utils.transactions import TRANSACTION_DEFAULTS
 
 from raiden.accounts import Account
 from raiden.log_config import _FIRST_PARTY_PACKAGES, configure_logging
+from raiden.utils import get_system_spec as raiden_system_spec
 from raiden.utils.cli import EnumChoiceType
-from scenario_player import tasks
+from scenario_player import __version__, tasks
 from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.exceptions.cli import WrongPassword
 from scenario_player.exceptions.services import ServiceProcessException
@@ -484,6 +486,20 @@ def post_to_rocket_chat(fpath, **rc_payload_fields):
         data=rc_payload_fields,
     )
     resp.raise_for_status()
+
+
+@main.command(name="version", help="Show versions of scenario_player and raiden environment.")
+@click.option(
+    "--short", is_flag=True, help="Only display scenario_player version string.", default=False
+)
+def version(short):
+    if short:
+        click.secho(message=__version__)
+    else:
+        spec = raiden_system_spec()
+        spec["scenario_player"] = __version__
+        spec["raiden-contracts"] = CONTRACTS_VERSION
+        click.secho(message=json.dumps(spec, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/unittests/cli/test_cli.py
+++ b/tests/unittests/cli/test_cli.py
@@ -7,13 +7,15 @@ from click.testing import CliRunner
 from scenario_player import main
 from scenario_player.exceptions.cli import WrongPassword
 
-KEYSTORE_PATH = str(Path(__file__).resolve().parents[0].joinpath("keystore"))
+KEYSTORE_PATH = Path(__file__).resolve().parent.joinpath("keystore")
 SCENARIO = f"{Path(__file__).parent.joinpath('scenario', 'join-network-scenario-J1.yaml')}"
-CLI_ARGS = f"--chain goerli:http://geth.goerli.ethnodes.brainbot.com:8545 run " \
-               f"--keystore-file " + KEYSTORE_PATH + "/UTC--1 " \
-               f"--no-ui " \
-               f"{{pw_option}} " \
-               f"{SCENARIO}"
+CLI_ARGS = (
+    f"--chain goerli:http://geth.goerli.ethnodes.brainbot.com:8545 "
+    f"--keystore-file {KEYSTORE_PATH.joinpath('UTC--1')} "
+    f"--no-ui "
+    f"{{pw_option}} "
+    f"{SCENARIO}"
+)
 
 
 @pytest.fixture(scope="module")
@@ -38,30 +40,31 @@ class TestPasswordHandling:
     def test_password_file_not_existent(self, runner):
         """A not existing password file should raise error"""
         result = runner.invoke(
-            main.main,
-            CLI_ARGS.format(pw_option=f"--password-file /does/not/exist").split(" ")
+            main.run, CLI_ARGS.format(pw_option=f"--password-file /does/not/exist").split(" ")
         )
         assert result.exit_code == 2
         assert '"--password-file": File "/does/not/exist" does not exist.' in result.output
 
     def test_mutually_exclusive(self, runner):
         result = runner.invoke(
-            main.main,
+            main.run,
             CLI_ARGS.format(
-                pw_option=
-                f"--password-file {KEYSTORE_PATH}" + "/password " + "--password 123").split(" ")
+                pw_option=f"--password-file {KEYSTORE_PATH.joinpath('password')} --password 123"
+            ).split(" "),
         )
         assert result.exit_code == 2
-        assert 'Error: Illegal usage: password_file is mutually exclusive' in result.output
+        assert "Error: Illegal usage: password_file is mutually exclusive" in result.output
 
     @pytest.mark.parametrize(
         "password_file, expected_exec",
-        argvalues=[("/wrong_password", WrongPassword), ("/password", Sentinel)],
+        argvalues=[("wrong_password", WrongPassword), ("password", Sentinel)],
         ids=["wrong password", "correct password"],
     )
     def test_password_file(self, password_file, expected_exec, runner):
-        result = runner.invoke(main.main, CLI_ARGS.format(
-            pw_option=f"--password-file {KEYSTORE_PATH + password_file}"))
+        result = runner.invoke(
+            main.run,
+            CLI_ARGS.format(pw_option=f"--password-file {KEYSTORE_PATH.joinpath(password_file)}"),
+        )
         assert result.exc_info[0] == expected_exec
         assert result.exit_code == 1
 
@@ -71,8 +74,9 @@ class TestPasswordHandling:
         ids=["wrong password", "correct password"],
     )
     def test_password(self, password, expected_exc, runner):
-        result = runner.invoke(main.main,
-                               CLI_ARGS.format(pw_option=f"--password {password}").split(" "))
+        result = runner.invoke(
+            main.run, CLI_ARGS.format(pw_option=f"--password {password}").split(" ")
+        )
         assert result.exc_info[0] == expected_exc
         assert result.exit_code == 1
 
@@ -82,7 +86,8 @@ class TestPasswordHandling:
         ids=["wrong password", "correct password"],
     )
     def test_manual_password_validation(self, user_input, expected_exc, runner):
-        result = runner.invoke(main.main,
-                               CLI_ARGS.format(pw_option=f"--password {user_input}").split(" "))
+        result = runner.invoke(
+            main.run, CLI_ARGS.format(pw_option=f"--password {user_input}").split(" ")
+        )
         assert result.exc_info[0] == expected_exc
         assert result.exit_code == 1

--- a/tests/unittests/cli/test_cli.py
+++ b/tests/unittests/cli/test_cli.py
@@ -1,10 +1,11 @@
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
-from scenario_player import main
+from scenario_player import __version__, main
 from scenario_player.exceptions.cli import WrongPassword
 
 KEYSTORE_PATH = Path(__file__).resolve().parent.joinpath("keystore")
@@ -91,3 +92,11 @@ class TestPasswordHandling:
         )
         assert result.exc_info[0] == expected_exc
         assert result.exit_code == 1
+
+    def test_version_subcommand(self, runner):
+        result = runner.invoke(main.version)
+        assert json.loads(result.output)["scenario_player"] == __version__
+        assert result.exit_code == 0
+        short = runner.invoke(main.version, "--short")
+        assert short.output.strip() == __version__
+        assert short.exit_code == 0


### PR DESCRIPTION
This fixes #186

I added a subcommand for `scenario_player version`. By default this will print an extended version of the json system spec of `raiden version` (added `scenario_player` version, `raiden-contracts` version).

In order to achieve that, I also refactored the general option parsing layout. 

#### Highlights:
- `--chain` is no longer mandatory for all subcommands
- the subcommands move to the front, i.e. `scenario_player run` instead of `scenario_player --chain ... run`

### Backwards compatibility:
The subcommand position is potentially a breaking change for scripts!
