### PR TITLE
[FEAT-#200] Show discrepancy for insufficient funds

### DIFF
--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -103,6 +103,8 @@ class ScenarioRunner:
             raise ScenarioError(
                 f"Insufficient balance ({balance / 10 ** 18} Eth) "
                 f'in account {to_checksum_address(account.address)} on chain "{self.chain_name}"'
+                f' - it needs additional {(OWN_ACCOUNT_BALANCE_MIN - balance) / 10 ** 18} Eth ('
+                f'that is {OWN_ACCOUNT_BALANCE_MIN - balance} Wei).'
             )
 
         self.session = Session()


### PR DESCRIPTION
Add additional information to `ScenarioError("Insufficient balance...")`.

Instead of only displaying the current balance, the scenario runner will now display the amount of missing funds.

Example output:
```
scenario_player.exceptions.legacy.ScenarioError: Insufficient balance (0.0 Eth) in account 0x7deB84d71D4D3a9Da135C9392f4c3FA7f976e20C on chain "goerli" - it needs additional 0.5 Eth (that is 500000000000000000 Wei).
```

This fixes #200 