### PR TITLE
[FIX-#8] Add empty value check for `--chain` parameter

### DIFF
--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -88,7 +88,7 @@ class ChainConfigType(click.ParamType):
 
     def convert(self, value, param, ctx):  # pylint: disable=unused-argument
         name, _, rpc_url = value.partition(":")
-        if name.startswith("http"):
+        if name.startswith("http") or "" in (name, rpc_url):
             self.fail(f"Invalid value: {value}. Use {self.get_metavar(None)}.")
         return name, rpc_url
 


### PR DESCRIPTION
This adds a simple check for empty values given in any of the `--chain <name>:<url>` arguments.

Fixes #8 