### PR TITLE
Introduce exit codes in exceptions

### DIFF
--- a/scenario_player/exceptions/legacy.py
+++ b/scenario_player/exceptions/legacy.py
@@ -1,57 +1,67 @@
 class ScenarioError(Exception):
-    pass
+    exit_code = 20
 
 
 class ScenarioTxError(ScenarioError):
-    pass
+    exit_code = 21
 
 
 class TokenRegistrationError(ScenarioTxError):
-    pass
+    exit_code = 22
+
+
+class TokenNetworkDiscoveryTimeout(TokenRegistrationError):
+    """If we waited a set time for the token network to be discovered, but it wasn't."""
+
+    exit_code = 22
 
 
 class ChannelError(ScenarioError):
-    pass
+    exit_code = 23
 
 
 class TransferFailed(ScenarioError):
-    pass
+    exit_code = 24
 
 
 class NodesUnreachableError(ScenarioError):
-    pass
+    exit_code = 25
 
 
 class RESTAPIError(ScenarioError):
-    pass
+    exit_code = 26
 
 
 class RESTAPIStatusMismatchError(ScenarioError):
-    pass
+    exit_code = 26
 
 
 class RESTAPITimeout(RESTAPIError):
-    pass
+    exit_code = 26
 
 
 class MultipleTaskDefinitions(ScenarioError):
     """Several root tasks were defined in the scenario configuration."""
 
+    exit_code = 27
+
 
 class InvalidScenarioVersion(ScenarioError):
-    pass
+    exit_code = 27
 
 
 class UnknownTaskTypeError(ScenarioError):
-    pass
+    exit_code = 27
 
 
 class MissingNodesConfiguration(ScenarioError, KeyError):
     """Could not find a key in the scenario file's 'nodes' section."""
 
+    exit_code = 28
+
 
 class ScenarioAssertionError(ScenarioError):
-    pass
+    exit_code = 30
 
 
 class BrokenArchive(Exception):
@@ -84,7 +94,3 @@ class FileOperationError(OSError):
     This is error is raised when we believe there may be a race condition causing
     our file to disappear.
     """
-
-
-class TokenNetworkDiscoveryTimeout(TokenRegistrationError):
-    """If we waited a set time for the token network to be discovered, but it wasn't."""

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -264,7 +264,7 @@ def run(
             account, chain_rpc_urls, auth, data_path, scenario_file, notify_tasks_callable
         )
     except Exception as e:
-        # log anything that goes wrong during init of the runner and isnt handled.
+        # log anything that goes wrong during init of the runner and isn't handled.
         log.exception(e)
         raise
 
@@ -281,16 +281,22 @@ def run(
             runner.run_scenario()
         except ScenarioAssertionError as ex:
             log.error("Run finished", result="assertion errors")
-            exit_code = 30
+            if hasattr(ex, "exit_code"):
+                exit_code = ex.exit_code
+            else:
+                exit_code = 30
             send_notification_mail(
                 runner.definition.settings.notify,
                 f"Assertion mismatch in {scenario_file.name}",
                 str(ex),
                 mailgun_api_key,
             )
-        except ScenarioError:
+        except ScenarioError as ex:
             log.exception("Run finished", result="scenario error")
-            exit_code = 20
+            if hasattr(ex, "exit_code"):
+                exit_code = ex.exit_code
+            else:
+                exit_code = 20
             send_notification_mail(
                 runner.definition.settings.notify,
                 f"Invalid scenario {scenario_file.name}",
@@ -307,9 +313,12 @@ def run(
                 "Success",
                 mailgun_api_key,
             )
-    except Exception:
+    except Exception as ex:
         log.exception("Exception while running scenario")
-        exit_code = 10
+        if hasattr(ex, "exit_code"):
+            exit_code = ex.exit_code
+        else:
+            exit_code = 10
         send_notification_mail(
             runner.definition.settings.notify,
             f"Error running scenario {scenario_file.name}",

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -265,7 +265,7 @@ def run(
         )
     except Exception as e:
         # log anything that goes wrong during init of the runner and isn't handled.
-        log.exception(e)
+        log.exception("Error during startup", exception=e)
         raise
 
     ui = None
@@ -275,57 +275,48 @@ def run(
         ui_greenlet = ui.run()
     success = False
     exit_code = 1
+    subject = None
+    message = None
 
     try:
-        try:
-            runner.run_scenario()
-        except ScenarioAssertionError as ex:
-            log.error("Run finished", result="assertion errors")
-            if hasattr(ex, "exit_code"):
-                exit_code = ex.exit_code
-            else:
-                exit_code = 30
-            send_notification_mail(
-                runner.definition.settings.notify,
-                f"Assertion mismatch in {scenario_file.name}",
-                str(ex),
-                mailgun_api_key,
-            )
-        except ScenarioError as ex:
-            log.exception("Run finished", result="scenario error")
-            if hasattr(ex, "exit_code"):
-                exit_code = ex.exit_code
-            else:
-                exit_code = 20
-            send_notification_mail(
-                runner.definition.settings.notify,
-                f"Invalid scenario {scenario_file.name}",
-                traceback.format_exc(),
-                mailgun_api_key,
-            )
+        runner.run_scenario()
+    except ScenarioAssertionError as ex:
+        log.error("Run finished", result="assertion errors")
+        if hasattr(ex, "exit_code"):
+            exit_code = ex.exit_code
         else:
-            success = True
-            exit_code = 0
-            log.info("Run finished", result="success")
-            send_notification_mail(
-                runner.definition.settings.notify,
-                f"Scenario successful {scenario_file.name}",
-                "Success",
-                mailgun_api_key,
-            )
+            exit_code = 30
+        subject = f"Assertion mismatch in {scenario_file.name}"
+        message = str(ex)
+    except ScenarioError as ex:
+        log.error("Run finished", result="scenario error")
+        if hasattr(ex, "exit_code"):
+            exit_code = ex.exit_code
+        else:
+            exit_code = 20
+        subject = f"Invalid scenario {scenario_file.name}"
+        message = traceback.format_exc()
     except Exception as ex:
         log.exception("Exception while running scenario")
         if hasattr(ex, "exit_code"):
             exit_code = ex.exit_code
         else:
             exit_code = 10
+        subject = f"Error running scenario {scenario_file.name}"
+        message = traceback.format_exc()
+    else:
+        success = True
+        exit_code = 0
+        log.info("Run finished", result="success")
+        subject = f"Scenario successful {scenario_file.name}"
+        message = "Success"
+    finally:
         send_notification_mail(
             runner.definition.settings.notify,
-            f"Error running scenario {scenario_file.name}",
-            traceback.format_exc(),
+            subject or "Logic error in main.py",
+            message or "Message should not be empty.",
             mailgun_api_key,
         )
-    finally:
         try:
             if enable_ui and ui:
                 ui.set_success(success)

--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -333,17 +333,20 @@ def send_notification_mail(target_mail, subject, message, api_key):
         return
 
     log.debug("Sending notification mail", subject=subject, message=message)
-    res = requests.post(
-        "https://api.mailgun.net/v3/notification.brainbot.com/messages",
-        auth=("api", api_key),
-        data={
-            "from": "Raiden Scenario Player <scenario-player@notification.brainbot.com>",
-            "to": [target_mail],
-            "subject": subject,
-            "text": message,
-        },
-    )
-    log.debug("Notification mail result", code=res.status_code, text=res.text)
+    try:
+        res = requests.post(
+            "https://api.mailgun.net/v3/notification.brainbot.com/messages",
+            auth=("api", api_key),
+            data={
+                "from": "Raiden Scenario Player <scenario-player@notification.brainbot.com>",
+                "to": [target_mail],
+                "subject": subject,
+                "text": message,
+            },
+        )
+        log.debug("Notification mail result", code=res.status_code, text=res.text)
+    except requests.exceptions.RequestException as e:
+        log.error("There was an error when sending the notification mail.", exception=str(e))
 
 
 def reclaim_eth(


### PR DESCRIPTION
This allows the cli to return more fine grained return values.

Fixes #393 

~~Missing tests still~~ This is painful to test, too much environment needs to be mocked / set up in order to test the flow. I'm open for suggestions though.