### PR TITLE
Implement default development environment when not specifying token address

### DIFF
--- a/scenario_player/definition.py
+++ b/scenario_player/definition.py
@@ -28,10 +28,11 @@ class ScenarioDefinition:
         self.path = yaml_path
         with yaml_path.open() as f:
             self._loaded = yaml.safe_load(f)
-        self.nodes = NodesConfig(self._loaded)
+        self.token = TokenConfig(self._loaded, data_path.joinpath("token.info"))
+        deploy_token = self.token.address is None
+        self.nodes = NodesConfig(self._loaded, environment="development" if deploy_token else None)
         self.settings = SettingsConfig(self._loaded)
         self.scenario = ScenarioConfig(self._loaded)
-        self.token = TokenConfig(self._loaded, data_path.joinpath("token.info"))
         self.spaas = SPaaSConfig(self._loaded)
 
         self.gas_limit = GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL * 2

--- a/scenario_player/utils/configuration/nodes.py
+++ b/scenario_player/utils/configuration/nodes.py
@@ -32,8 +32,13 @@ class NodesConfig(ConfigMapping):
 
     CONFIGURATION_ERROR = NodeConfigurationError
 
-    def __init__(self, loaded_definition: dict):
+    def __init__(self, loaded_definition: dict, environment=None):
         super(NodesConfig, self).__init__(loaded_definition.get("nodes") or {})
+        if environment is not None:
+            default_options = self.dict.get("default_options", {})
+            if "environment-type" not in default_options:
+                default_options["environment-type"] = environment
+            self.dict["default_options"] = default_options
         self.validate()
 
     @property

--- a/tests/unittests/test_scenario_definition.py
+++ b/tests/unittests/test_scenario_definition.py
@@ -1,0 +1,44 @@
+import json
+import pathlib
+
+import pytest
+
+from scenario_player.definition import ScenarioDefinition
+
+
+@pytest.mark.parametrize(
+    "token,default_options,environment_type",
+    [
+        (dict(), None, "development"),
+        (dict(), dict(), "development"),
+        (dict(address=""), dict(), None),
+        (dict(address=""), {"environment-type": "production"}, "production"),
+        (dict(), {"environment-type": "production"}, "production"),
+    ],
+    ids=[
+        "deal_with_None",
+        "default_environment_type",
+        "no_change",
+        "standard_behavior",
+        "respect_override",
+    ],
+)
+def test_environment_default_type_on_token(tmpdir, token, default_options, environment_type):
+    dir = tmpdir.mkdtemp()
+    testfile = dir.join("test.yaml")
+    with open(testfile, "w") as f:
+        data = dict(
+            version=2,
+            settings=dict(),
+            token=token,
+            nodes=dict(count=1, default_options=default_options)
+            if default_options is not None
+            else dict(count=1),
+            scenario=dict(serial=dict()),
+        )
+        json.dump(data, f)
+    definition = ScenarioDefinition(yaml_path=pathlib.Path(testfile), data_path=pathlib.Path(dir))
+    if environment_type is not None:
+        assert definition.nodes.default_options["environment-type"] == environment_type
+    else:
+        assert "environment-type" not in definition.nodes.default_options


### PR DESCRIPTION
As requested in #377, this changes the scenario definition parser to:

- when specifying a token to be deployed, `environment-type: development` is implied automatically for all nodes by the SP and it is not necessary to state this in the scenario file.
- if a token is specified to be deployed and `environment-type: production` is set, this setting is honored (overriding any implied environment type).
    
This fixes #377
