### PR TITLE
[FEAT-#334] Store scenario settings in ScenarioDefinition only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ style: isort black
 lint: flake8 black-check isort-check
 
 install:
-	pip install .
+	pip install --force-reinstall -U .
 
 install-dev:
 	pip install ".[dev]"

--- a/scenario_player/constants.py
+++ b/scenario_player/constants.py
@@ -27,6 +27,13 @@ GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL = 100_000
 RUN_NUMBER_FILENAME = "run_number.txt"
 
 
+#: Ethereum Nodes hosted by Brainbot
+BB_ETH_RPC_ADDRESS = "http://{client}.{network}.ethnodes.brainbot.com:5085"
+DEFAULT_CLIENT = "parity"
+DEFAULT_NETWORK = "goerli"
+DEFAULT_ETH_RPC_ADDRESS = BB_ETH_RPC_ADDRESS.format(client=DEFAULT_CLIENT, network=DEFAULT_NETWORK)
+
+
 class NodeMode(enum.Enum):
     EXTERNAL = 1
     MANAGED = 2

--- a/scenario_player/definition.py
+++ b/scenario_player/definition.py
@@ -28,10 +28,12 @@ class ScenarioDefinition:
         self.path = yaml_path
         with yaml_path.open() as f:
             self._loaded = yaml.safe_load(f)
+        self._scenario_dir = None
         self.token = TokenConfig(self._loaded, data_path.joinpath("token.info"))
         deploy_token = self.token.address is None
         self.nodes = NodesConfig(self._loaded, environment="development" if deploy_token else None)
         self.settings = SettingsConfig(self._loaded)
+        self.settings.sp_root_dir = data_path
         self.scenario = ScenarioConfig(self._loaded)
         self.spaas = SPaaSConfig(self._loaded)
 
@@ -41,3 +43,10 @@ class ScenarioDefinition:
     def name(self) -> str:
         """Return the name of the scenario file, sans extension."""
         return self.path.stem
+
+    @property
+    def scenario_dir(self):
+        if not self._scenario_dir:
+            self._scenario_dir = self.settings.sp_scenario_root_dir.joinpath(self.name)
+            self._scenario_dir.mkdir(exist_ok=True, parents=True)
+        return self._scenario_dir

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -5,7 +5,6 @@ import json
 import os
 import sys
 import traceback
-from collections import defaultdict
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -21,6 +20,7 @@ from raiden.accounts import Account
 from raiden.log_config import _FIRST_PARTY_PACKAGES, configure_logging
 from raiden.utils.cli import EnumChoiceType
 from scenario_player import __version__, tasks
+from scenario_player.constants import DEFAULT_ETH_RPC_ADDRESS, DEFAULT_NETWORK
 from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.exceptions.cli import WrongPassword
 from scenario_player.exceptions.services import ServiceProcessException
@@ -28,12 +28,7 @@ from scenario_player.runner import ScenarioRunner
 from scenario_player.services.common.app import ServiceProcess
 from scenario_player.tasks.base import collect_tasks
 from scenario_player.ui import ScenarioUI, attach_urwid_logbuffer
-from scenario_player.utils import (
-    ChainConfigType,
-    DummyStream,
-    post_task_state_to_rc,
-    send_notification_mail,
-)
+from scenario_player.utils import DummyStream, post_task_state_to_rc, send_notification_mail
 from scenario_player.utils.legacy import MutuallyExclusiveOption
 from scenario_player.utils.version import get_complete_spec
 
@@ -69,13 +64,6 @@ def configure_logging_for_subcommand(log_file_name):
         _first_party_packages=_FIRST_PARTY_PACKAGES | frozenset(["scenario_player"]),
         _debug_log_file_additional_level_filters={"scenario_player": "DEBUG"},
     )
-
-
-def parse_chain_rpc_urls(list_of_urls):
-    chain_rpc_urls = defaultdict(list)
-    for chain_name, chain_rpc_url in list_of_urls:
-        chain_rpc_urls[chain_name].append(chain_rpc_url)
-    return chain_rpc_urls
 
 
 def load_account_obj(keystore_file, password):
@@ -147,11 +135,10 @@ def chain_option(func):
 
     @click.option(
         "--chain",
-        "chains",
-        type=ChainConfigType(),
-        multiple=True,
-        required=True,
-        help="Chain name to eth rpc url mapping, multiple allowed",
+        "chain",
+        multiple=False,
+        required=False,
+        help="Chain name to eth rpc url mapping.",
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -188,7 +175,7 @@ def main(ctx):
 @click.pass_context
 def run(
     ctx,
-    chains,
+    chain,
     data_path,
     mailgun_api_key,
     auth,
@@ -216,7 +203,6 @@ def run(
         There was an assertion error while executing the scenario. This points
         to an error in a `raiden` component (the client, services or contracts).
     """
-    chain_rpc_urls = parse_chain_rpc_urls(chains)
     data_path = Path(data_path)
     scenario_file = Path(scenario_file.name).absolute()
     log_file_name = construct_log_file_name("run", data_path, scenario_file)
@@ -253,7 +239,7 @@ def run(
     # Run the scenario using the configurations passed.
     try:
         runner = ScenarioRunner(
-            account, chain_rpc_urls, auth, data_path, scenario_file, notify_tasks_callable
+            account, chain, auth, data_path, scenario_file, notify_tasks_callable
         )
     except Exception as e:
         # log anything that goes wrong during init of the runner and isn't handled.
@@ -337,12 +323,16 @@ def run(
 @chain_option
 @data_path_option
 @click.pass_context
-def reclaim_eth(ctx, min_age, password, password_file, keystore_file, chains, data_path):
+def reclaim_eth(ctx, min_age, password, password_file, keystore_file, chain, data_path):
     from scenario_player.utils import reclaim_eth
 
     data_path = Path(data_path)
+    if not chain:
+        chain_rpc_urls = {DEFAULT_NETWORK: DEFAULT_ETH_RPC_ADDRESS}
+    else:
+        network, url = chain.split(":", maxsplit=1)
+        chain_rpc_urls = {network: url}
 
-    chain_rpc_urls = parse_chain_rpc_urls(chains)
     password = get_password(password, password_file)
     account = get_account(keystore_file, password)
 

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -175,7 +175,9 @@ class NodeRunner:
         self._index = index
         self._raiden_version = raiden_version
         self._options = options
-        self._datadir = runner.data_path.joinpath(f"node_{self._runner.run_number}_{index:03d}")
+        self._datadir = runner.definition.scenario_dir.joinpath(
+            f"node_{self._runner.run_number}_{index:03d}"
+        )
 
         self._address = None
         self._eth_rpc_endpoint = None
@@ -291,7 +293,7 @@ class NodeRunner:
             "--password-file",
             self._password_file,
             "--network-id",
-            self._runner.chain_id,
+            self._runner.definition.settings.chain_id,
             "--sync-check",  # FIXME: Disable sync check for private chains
             "--gas-price",
             self._options.get("gas-price", "normal"),

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -30,7 +30,6 @@ from scenario_player.constants import (
 from scenario_player.definition import ScenarioDefinition
 from scenario_player.exceptions import ScenarioError, TokenRegistrationError
 from scenario_player.exceptions.legacy import TokenNetworkDiscoveryTimeout
-from scenario_player.services.rpc.utils import assign_rpc_instance_id
 from scenario_player.services.utils.interface import ServiceInterface
 from scenario_player.utils import TimeOutHTTPAdapter, get_udc_and_token, wait_for_txs
 from scenario_player.utils.token import Token, UserDepositContract
@@ -45,10 +44,10 @@ class ScenarioRunner:
     def __init__(
         self,
         account: Account,
-        chain_urls: Dict[str, List[str]],
         auth: str,
         data_path: Path,
         scenario_file: Path,
+        chain_url: Optional[str] = None,
         task_state_callback: Optional[
             Callable[["ScenarioRunner", "Task", "TaskState"], None]
         ] = None,
@@ -66,36 +65,28 @@ class ScenarioRunner:
         # Storage for arbitrary data tasks might need to persist
         self.task_storage = defaultdict(dict)
 
-        scenario_name = scenario_file.stem
-        self.base_path = data_path
-        self.base_path.mkdir(exist_ok=True, parents=True)
+        self.definition = ScenarioDefinition(scenario_file, data_path)
 
         log.debug("Local seed", seed=self.local_seed)
 
-        self.data_path = self.base_path.joinpath("scenarios", scenario_name)
-        self.data_path.mkdir(exist_ok=True, parents=True)
-
-        self.definition = ScenarioDefinition(scenario_file, self.data_path)
-        log.debug("Data path", path=self.data_path)
-
-        # Determining the run number requires :attr:`.data_path`
         self.run_number = self.determine_run_number()
 
         self.node_controller = NodeController(self, self.definition.nodes)
 
         self.protocol = "http"
+        if chain_url:
+            name, endpoint = chain_url.split(":", maxsplit=1)
+            # Set CLI overrides.
+            self.definition.settings._cli_chain = name
+            self.definition.settings._cli_rpc_address = endpoint
 
-        self.gas_limit = GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL * 2
-
-        self.chain_name, chain_urls = self.select_chain(chain_urls)
-        self.eth_rpc_urls = chain_urls
         self.client = JSONRPCClient(
-            Web3(HTTPProvider(chain_urls[0])),
+            Web3(HTTPProvider(self.definition.settings.eth_client_rpc_address)),
             privkey=account.privkey,
             gas_price_strategy=self.definition.settings.gas_price_strategy,
         )
-        self.chain_id = int(self.client.web3.net.version)
 
+        self.definition.settings.chain_id = int(self.client.web3.net.version)
         self.contract_manager = ContractManager(contracts_precompiled_path())
 
         balance = self.client.balance(account.address)
@@ -114,11 +105,10 @@ class ScenarioRunner:
         self.session.mount("https", TimeOutHTTPAdapter(timeout=self.definition.settings.timeout))
 
         self.service_session = ServiceInterface(self.definition.spaas)
-        # Request an RPC Client instance ID from the RPC service and assign it to the runner.
-        assign_rpc_instance_id(
-            self, chain_urls[0], account.privkey, self.definition.settings.gas_price
+        # Assign an RPC Client instance ID on the RPC service, for this run.
+        self.definition.spaas.rpc.assign_rpc_instance(
+            self, account.privkey, self.definition.settings.gas_price
         )
-
         self.token = Token(self, data_path)
         self.udc = None
 
@@ -137,7 +127,7 @@ class ScenarioRunner:
         REFAC: Replace this with a property.
         """
         run_number = 0
-        run_number_file = self.data_path.joinpath(RUN_NUMBER_FILENAME)
+        run_number_file = self.definition.scenario_dir.joinpath(RUN_NUMBER_FILENAME)
         if run_number_file.exists():
             run_number = int(run_number_file.read_text()) + 1
         run_number_file.write_text(str(run_number))
@@ -152,9 +142,9 @@ class ScenarioRunner:
         This is used in the node private key generation to prevent re-use of node keys between
         multiple users of the scenario player.
 
-        The seed is stored in a file inside the ``.base_path``.
+        The seed is stored in a file inside the ``.definition.settings.sp_root_dir``.
         """
-        seed_file = self.base_path.joinpath("seed.txt")
+        seed_file = self.definition.settings.sp_root_dir.joinpath("seed.txt")
         if not seed_file.exists():
             seed = encode_hex(bytes(random.randint(0, 255) for _ in range(20)))
             seed_file.write_text(seed)

--- a/scenario_player/services/rpc/utils.py
+++ b/scenario_player/services/rpc/utils.py
@@ -4,19 +4,11 @@ from collections.abc import Mapping
 from typing import Callable, Tuple, Union
 
 import structlog
-from eth_utils import encode_hex
 from web3 import HTTPProvider, Web3
 
 from raiden.network.rpc.client import JSONRPCClient
 
 log = structlog.getLogger(__name__)
-
-
-def assign_rpc_instance_id(runner, chain_url, privkey, gas_price):
-    params = {"chain_url": chain_url, "privkey": encode_hex(privkey), "gas_price": gas_price}
-    resp = runner.service_session.post("spaas://rpc/client", json=params)
-    client_id = resp.json()["client_id"]
-    runner.definition.spaas.rpc.client_id = client_id
 
 
 def generate_hash_key(chain_url: str, privkey: bytes, strategy: Callable):

--- a/scenario_player/tasks/blockchain.py
+++ b/scenario_player/tasks/blockchain.py
@@ -142,7 +142,7 @@ class AssertBlockchainEventsTask(Task):
         # get the correct contract address
         # this has to be done in `_run`, otherwise `_runner` is not initialized yet
         contract_data = get_contracts_deployment_info(
-            chain_id=self._runner.chain_id, version=RAIDEN_CONTRACT_VERSION
+            chain_id=self._runner.definition.settings.chain_id, version=RAIDEN_CONTRACT_VERSION
         )
         if self.contract_name == CONTRACT_TOKEN_NETWORK:
             self.contract_address = self._runner.token_network_address
@@ -203,7 +203,7 @@ class AssertMSClaimTask(Task):
 
         # get the MS contract address
         contract_data = get_contracts_deployment_info(
-            chain_id=self._runner.chain_id, version=RAIDEN_CONTRACT_VERSION
+            chain_id=self._runner.definition.settings.chain_id, version=RAIDEN_CONTRACT_VERSION
         )
         try:
             contract_info = contract_data["contracts"][self.contract_name]

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -2,13 +2,20 @@ from typing import Callable, Union
 
 import structlog
 
-from scenario_player.constants import GAS_STRATEGIES, TIMEOUT
+from scenario_player.constants import (
+    BB_ETH_RPC_ADDRESS,
+    DEFAULT_CLIENT,
+    DEFAULT_NETWORK,
+    GAS_STRATEGIES,
+    TIMEOUT,
+)
 from scenario_player.exceptions.config import (
     ScenarioConfigurationError,
     ServiceConfigurationError,
     UDCTokenConfigError,
 )
 from scenario_player.utils.configuration.base import ConfigMapping
+from scenario_player.utils.types import NetlocWithPort
 
 log = structlog.get_logger(__name__)
 
@@ -183,6 +190,20 @@ class SettingsConfig(ConfigMapping):
         super(SettingsConfig, self).__init__(loaded_definition.get("settings") or {})
         self.services = ServiceSettingsConfig(loaded_definition)
         self.validate()
+        # If chain or rpc address are given via CLI, they override the scenario
+        # definition values. These attributes store these overrides.
+        self._cli_rpc_address = None
+        self._cli_chain = None
+        self.sp_root_dir = None
+        self._sp_scenario_root_dir = None
+
+    @property
+    def sp_scenario_root_dir(self):
+        if not self._sp_scenario_root_dir:
+            self._sp_scenario_root_dir = self.sp_root_dir.joinpath("scenarios")
+            self._sp_scenario_root_dir.mkdir(exist_ok=True, parents=True)
+
+        return self._sp_scenario_root_dir
 
     def validate(self):
         self.assert_option(
@@ -212,8 +233,47 @@ class SettingsConfig(ConfigMapping):
 
     @property
     def chain(self) -> str:
-        """Return the name of the chain to be used for this scenario."""
-        return self.get("chain", "any")
+        """Return the name of the chain to be used for this scenario.
+
+        Defaults to :var:`DEFAULT_NETWORK` test net.
+        """
+        return self._cli_chain or self.get("chain", DEFAULT_NETWORK)
+
+    @property
+    def chain_id(self):
+        """Return the chain ID for the configured chain.
+
+        This is set by the scenario player, and overridden if given
+        in the scenario definition file.
+        """
+        return self.get("chain_id")
+
+    @property
+    def eth_client(self) -> str:
+        """Return the Ethereum Client to use.
+
+        This should be the name of the executable, not a path.
+
+        Defaults to :var:`DEFAULT_CLIENT`.
+        """
+        return self.get("eth-client", DEFAULT_CLIENT)
+
+    @property
+    def eth_client_rpc_address(self) -> NetlocWithPort:
+        """Return the Ethereum client's RPC address.
+
+        The value is loaded in the following order:
+
+            - `--chain` value passed via CLI
+            - `eth-client-rpc-address` value in the scenario definition file
+            - :var:`BB_ETH_RPC_ADDRESS`, populated with values of
+             :attr:`.chain` and :attr:`.eth_client`.
+
+        """
+        return self._cli_rpc_address or self.get(
+            "eth-client-rpc-address",
+            BB_ETH_RPC_ADDRESS.format(network=self.chain, client=self.eth_client),
+        )
 
     @property
     def gas_price(self) -> str:

--- a/scenario_player/utils/configuration/spaas.py
+++ b/scenario_player/utils/configuration/spaas.py
@@ -1,4 +1,5 @@
 import structlog
+from eth_utils import encode_hex
 
 from scenario_player.utils.configuration.base import ConfigMapping
 
@@ -59,3 +60,14 @@ class RPCServiceConfig(SPaaSServiceConfig):
     def __init__(self, spaas_config: dict):
         super(RPCServiceConfig, self).__init__(spaas_config.get("rpc") or {})
         self.client_id = None
+
+    def assign_rpc_instance(self, runner, privkey, gas_price):
+        """Assign this SP instance an RPC Client to use when making write-requests."""
+        params = {
+            "chain_url": runner.definition.settings.eth_client_rpc_address,
+            "privkey": encode_hex(privkey),
+            "gas_price": gas_price,
+        }
+        resp = runner.service_session.post("spaas://rpc/client", json=params)
+        client_id = resp.json()["client_id"]
+        self.client_id = client_id

--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -231,7 +231,7 @@ def get_or_deploy_token(runner) -> Tuple[ContractProxy, int]:
     block = token_config.get("block", 0)
     reuse = token_config.get("reuse", False)
 
-    token_address_file = runner.data_path.joinpath("token.infos")
+    token_address_file = runner.definition.settings.sp_scenario_dir.joinpath("token.infos")
     if reuse:
         if address:
             raise ScenarioError('Token settings "address" and "reuse" are mutually exclusive.')
@@ -289,7 +289,7 @@ def get_udc_and_token(runner) -> Tuple[Optional[ContractProxy], Optional[Contrac
     udc_address = udc_config.address
     if udc_address is None:
         contracts = get_contracts_deployment_info(
-            chain_id=runner.chain_id, version=RAIDEN_CONTRACT_VERSION
+            chain_id=runner.definition.settings.chain_id, version=RAIDEN_CONTRACT_VERSION
         )
         udc_address = contracts["contracts"][CONTRACT_USER_DEPOSIT]["address"]
     udc_abi = runner.contract_manager.get_contract_abi(CONTRACT_USER_DEPOSIT)

--- a/scenario_player/utils/types.py
+++ b/scenario_player/utils/types.py
@@ -1,0 +1,14 @@
+from typing import NewType
+
+#: A string representing a network location, i.e. any str matching
+#: the pattern stated in RFC1808 Section 2.1 - <user>:<password>@<host>:<port>.
+#: Typically, we only require the netloc to match the following regex::
+#:
+#:      r"^((?P<credentials>(?P<user>\w+):(?P<pw>.+))@)?(?P<host>.+)(:(?P<port>\d+)?)$"
+#:
+#: Where the group `credentials` is optional, but the group `port` is required.
+#: Note that the latter breaks with the RFC definition, which states that `port`
+#: may be optional as well.
+#: The reason for this is that the Raiden Executable requires netlocs to include
+#: a port number.
+NetlocWithPort = NewType("Netloc", str)

--- a/tests/unittests/cli/test_cli.py
+++ b/tests/unittests/cli/test_cli.py
@@ -13,7 +13,6 @@ from scenario_player.exceptions.cli import WrongPassword
 KEYSTORE_PATH = Path(__file__).resolve().parent.joinpath("keystore")
 SCENARIO = f"{Path(__file__).parent.joinpath('scenario', 'join-network-scenario-J1.yaml')}"
 CLI_ARGS = (
-    f"--chain goerli:http://geth.goerli.ethnodes.brainbot.com:8545 "
     f"--keystore-file {KEYSTORE_PATH.joinpath('UTC--1')} "
     f"--no-ui "
     f"{{pw_option}} "
@@ -119,7 +118,6 @@ class TestDataPathBehavior:
         result = runner.invoke(
             main.reclaim_eth,
             f"--data-path {path_arg} "
-            f"--chain a:b "
             f"--password-file {KEYSTORE_PATH.joinpath('password')} "
             f"--keystore-file {KEYSTORE_PATH.joinpath('UTC--1')} ",
         )

--- a/tests/unittests/services/rpc/schemas/conftest.py
+++ b/tests/unittests/services/rpc/schemas/conftest.py
@@ -1,4 +1,8 @@
-from tests.unittests.services.rpc.conftest import *
+import flask
+import pytest
+
+from scenario_player.services.rpc.schemas.tokens import TokenCreateSchema, ContractTransactSchema
+from scenario_player.services.rpc.utils import RPCRegistry, RPCClient
 
 
 @pytest.fixture

--- a/tests/unittests/utils/configuration/conftest.py
+++ b/tests/unittests/utils/configuration/conftest.py
@@ -1,8 +1,4 @@
-import json
-
 import pytest
-
-from ..conftest import minimal_definition_dict, token_info_path
 
 
 @pytest.fixture
@@ -16,7 +12,7 @@ def expected_defaults():
             "gas_price": "FAST",
             "timeout": 200,
             "notify": None,
-            "chain": "any",
+            "chain": "goerli",
             "services": {},
         },
         "token": {"address": None, "block": 0, "reuse": False, "symbol": str(), "decimals": 0},

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -86,6 +86,18 @@ class TestSettingsConfig:
         config = SettingsConfig(minimal_definition_dict)
         assert config.gas_price_strategy == expected_func
 
+    def test_chain_property_prioritizes_cli_attr_over_scenario_definition(self, minimal_definition_dict):
+        minimal_definition_dict["chain"] = "kovan"
+        instance = SettingsConfig(minimal_definition_dict)
+        instance._cli_chain = "my_chain"
+        assert instance.chain == "my_chain"
+
+    def test_eth_rpc_address_property_prioritizes_cli_attr_over_scenario_definition(self, minimal_definition_dict):
+        instance = SettingsConfig(minimal_definition_dict)
+        instance._cli_rpc_address = "my_address"
+        minimal_definition_dict["settings"]["eth-client-rpc-address"] = "http://ethnodes.io"
+        assert instance.eth_client_rpc_address == "my_address"
+
 
 class TestServiceSettingsConfig:
     def test_is_subclass_of_config_mapping(self, minimal_definition_dict):

--- a/tests/unittests/utils/conftest.py
+++ b/tests/unittests/utils/conftest.py
@@ -2,9 +2,6 @@ import json
 
 import pytest
 
-from ..conftest import dummy_scenario_runner, minimal_definition_dict
-
-
 @pytest.fixture
 def token_info_path(tmp_path):
     path = tmp_path.joinpath("token.info")

--- a/tests/unittests/utils/test_token.py
+++ b/tests/unittests/utils/test_token.py
@@ -43,9 +43,11 @@ class Sentinel(Exception):
 def hex_address():
     return "0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c"
 
+
 @pytest.fixture
 def contract_addr():
     return "0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c"
+
 
 @pytest.fixture
 def runner(dummy_scenario_runner, minimal_definition_dict, token_info_path, tmp_path):
@@ -354,6 +356,7 @@ class TestToken:
 
     @patch(f"{token_import_path}.Token.load_from_file", side_effect=Sentinel)
     def test_use_exising_loads_token_info_file(self, _, token_instance):
+        # use_existing() requires `reuse` or `address` keys set in dict.
         token_instance.config.token.dict["reuse"] = True
         with pytest.raises(Sentinel):
             token_instance.use_existing()
@@ -366,13 +369,14 @@ class TestToken:
     def test_uses_existing_raises_error_if_address_has_no_sourcecode(
         self, _, mock_check_address, token_instance
     ):
-        # Extend the definition with the proper base settings.
+        # use_existing() requires `reuse` or `address` keys set in dict.
         token_instance.config.token.dict["reuse"] = True
 
         def raise_exc(*args, **kwargs):
             raise AddressWithoutCode
 
         mock_check_address.side_effect = raise_exc
+
         with pytest.raises(TokenSourceCodeDoesNotExist):
             token_instance.use_existing()
 
@@ -382,6 +386,7 @@ class TestToken:
     def test_use_existing_assigns_contract_data_and_deployment_receipt_correctly(
         self, mock_load_from_file, _, __, token_instance
     ):
+        # use_existing() requires `reuse` or `address` keys set in dict.
         token_instance.config.token.dict["reuse"] = True
 
         loaded_token_info = {"address": "my_address", "name": "my_token_name", "block": 1}


### PR DESCRIPTION
Stores all scenario-related options in the ScenarioDefinition
object or a mapping it contains.

Makes --chain optional, and only allows one instance of it to be
passed. Default chain is `goerli`, default node is
 `parity.goerli.ethnodes.brainbot.com:8545`.

Rationale behind making `--chain` optional is that passing it multiple times is not used in prod, nor is using the option `chain: any` in the scenario definitions.

~I'm currently still running into issues with the CLI tests, which seem to fail due to some unpacking error.~ 