### PR TITLE
Add COMMIT_TYPES.BUMP to parts dict.

### DIFF
--- a/.circleci/scripts/bump-part.py
+++ b/.circleci/scripts/bump-part.py
@@ -19,6 +19,7 @@ CI_CONFIG_DIR = os.environ["CI_CONFIG_DIR"]
 parts = {
     COMMIT_TYPES.FEAT: "minor",
     COMMIT_TYPES.FIX: "patch",
+    COMMIT_TYPES.BUMP: "bump_version",
 }
 
 PART = parts[COMMIT_TYPE]


### PR DESCRIPTION
Previously was undefined, causing the CI to show up as failed.
This fix corrects this bug, making the CI pass
again correctly.