### PR TITLE
Hotfix: Token network registration / node stop timeout

### DIFF
--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -222,7 +222,8 @@ class NodeRunner:
         log.info("Node started", node=self._index, duration=duration)
         return ret
 
-    def stop(self, timeout=60):
+    # FIXME: Make node stop configurable?
+    def stop(self, timeout=180):
         log.info("Stopping node", node=self._index)
         begin = time.monotonic()
 

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -267,7 +267,8 @@ class ScenarioRunner:
                 code, msg = self.register_token(self.token.checksum_address, first_node)
                 if 199 < code < 300:
                     break
-                gevent.sleep(1)
+                # FIXME: Remove long sleep and instead intelligently handle Raiden 5 block wait
+                gevent.sleep(15)
             else:
                 log.error("Couldn't register token with network", code=code, message=msg)
                 raise TokenRegistrationError(msg)


### PR DESCRIPTION
Two hotfixes (sorry @nlsdfnbch :(): 
- Increase token registration retry wait
- Increase node stop timeout