### PR TITLE
Restore optional account reuse + Snapshot support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,12 @@ black-check:
 flake8:
 	flake8 scenario_player
 
+pylint:
+	pylint scenario_player
+
 style: isort black
 
-lint: mypy flake8 black-check isort-check
+lint: mypy flake8 pylint black-check isort-check
 
 format: isort black
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,76 @@
+[MASTER]
+jobs=4
+persistent=yes
+suggestion-mode=yes
+unsafe-load-any-extension=no
+
+# Blacklist files or directories (basenames, not paths)
+ignore=
+
+# blacklist files or directories by regex  (basenames, not paths)
+ignore-patterns=
+
+[EXCEPTIONS]
+
+overgeneral-exceptions=Exception,RaidenUnrecoverableError
+
+[BASIC]
+
+bad-names=foo,bar,baz,toto,tutu,tata
+good-names=i,j,k,_,log
+
+[LOGGING]
+
+logging-modules=logging,structlog
+
+[MESSAGES CONTROL]
+
+disable=all
+enable=
+    assert-message,
+    bad-except-order,
+    expression-not-assigned,
+    import-self,
+    inconsistent-return-statements,
+    no-member,
+    no-self-use,
+    no-value-for-parameter,
+    pointless-statement,
+    redefined-builtin,
+    reimported,
+    too-many-format-args,
+    too-many-function-args,
+    unexpected-keyword-arg,
+    unused-argument,
+    unused-import,
+    unused-variable,
+    useless-object-inheritance,
+
+[REPORTS]
+
+reports=no
+score=no
+
+[FORMAT]
+
+expected-line-ending-format=LF
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+max-line-length=100
+max-module-lines=1000
+no-space-check=trailing-comma
+
+[VARIABLES]
+
+callbacks=cb_,_cb
+dummy-variables-rgx=_
+ignored-argument-names=_.*
+
+[TYPECHECK]
+
+contextmanager-decorators=contextlib.contextmanager
+
+# List of class names for which member attributes should not be checked
+ignored-classes=
+
+# List of module names for which member attributes should not be checked
+ignored-modules=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ requires = [
     'click',
     'eth-utils',
     'gevent',
-    'pyyaml',
-    'requests',
-    'raiden',
-    'structlog',
-    'simplejson',
-    'urwid!=2.1.0',
-    'waitress',
     'jinja2',
+    'prometheus_client<0.8.0',
+    'pyyaml',
+    'raiden',
+    'requests',
+    'simplejson',
+    'structlog',
+    'urwid!=2.1.0',
 ]
 
 # Classifiers, Licensing, keywords for pypi.
@@ -53,7 +53,7 @@ keywords = "raiden, raiden-network"
 [tool.flit.metadata.requires-extra]
 # Extended dependencies required for development and testing. Flit installs
 # these automatically.
-test = ["pytest==4.5.0"]
+test = ["pytest"]
 dev = [
     "black==19.3b0",
     "coverage",
@@ -64,7 +64,7 @@ dev = [
     "isort==4.3.16",
     "matrix-synapse==1.10.1",
     "mypy==0.761",
-    "pytest",
+    "pylint",
     "pytest-cov",
     "pytest-dependency==0.4.0",
     "responses==0.10.6",

--- a/scenario_player/__main__.py
+++ b/scenario_player/__main__.py
@@ -6,4 +6,4 @@ monkey.patch_all()  # isort:skip
 from .main import main
 
 if __name__ == "__main__":
-    main()
+    main()  # pylint: disable=no-value-for-parameter

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -295,6 +295,13 @@ class ScenarioRunner:
 
         self.session = make_session(auth, self.definition.settings)
 
+        self.node_controller = NodeController(
+            self, self.definition.nodes, delete_snapshots=self.delete_snapshots
+        )
+        task_config = self.definition.scenario.root_config
+        task_class = self.definition.scenario.root_class
+        self.root_task = task_class(runner=self, config=task_config)
+
     @property
     def local_seed(self) -> str:
         """Return a persistent random seed value.
@@ -336,9 +343,7 @@ class ScenarioRunner:
 
     def run_scenario(self) -> None:
         with Janitor() as nursery:
-            self.node_controller = NodeController(
-                self, self.definition.nodes, nursery, delete_snapshots=self.delete_snapshots
-            )
+            self.node_controller.set_nursery(nursery)
             self.node_controller.initialize_nodes()
 
             try:
@@ -456,19 +461,13 @@ class ScenarioRunner:
             token_network_address=to_checksum_address(token_network_address),
         )
 
-        task_config = self.definition.scenario.root_config
-        task_class = self.definition.scenario.root_class
-
-        root_task = task_class(runner=self, config=task_config)
-
         # Expose attributes used by the tasks
         self.token = token_proxy
-        self.root_task = root_task
         self.contract_manager = proxy_manager.contract_manager
         self.token_network_address = to_checksum_address(token_network_address)
         self.block_execution_started = block_execution_started
 
-        root_task()
+        self.root_task()
 
     def setup_raiden_nodes_ether_balances(
         self, pool: Pool, node_addresses: Set[ChecksumAddress]

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -17,6 +17,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
 )
 from raiden_contracts.contract_manager import DeployedContracts, get_contracts_deployment_info
+from raiden_contracts.utils.type_aliases import TokenAmount
 from requests import HTTPError, Session
 from web3 import HTTPProvider, Web3
 
@@ -35,7 +36,6 @@ from raiden.utils.typing import (
     Address,
     ChainID,
     TokenAddress,
-    TokenAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
 )
@@ -49,7 +49,7 @@ from scenario_player.constants import (
 )
 from scenario_player.definition import ScenarioDefinition
 from scenario_player.exceptions import ScenarioError, TokenNetworkDiscoveryTimeout
-from scenario_player.node_support import NodeController, NodeRunner, RaidenReleaseKeeper
+from scenario_player.node_support import NodeController, NodeRunner
 from scenario_player.utils import TimeOutHTTPAdapter
 from scenario_player.utils.configuration.settings import (
     EnvironmentConfig,
@@ -240,9 +240,15 @@ class ScenarioRunner:
             Callable[["ScenarioRunner", "Task", "TaskState"], None]
         ] = None,
         smoketest_deployment_data: DeployedContracts = None,
+        delete_snapshots: bool = False,
     ) -> None:
+        from scenario_player.node_support import RaidenReleaseKeeper
+
+        self.auth = auth
 
         self.smoketest_deployment_data = smoketest_deployment_data
+        self.delete_snapshots = delete_snapshots
+
         self.release_keeper = RaidenReleaseKeeper(data_path.joinpath("raiden_releases"))
         self.data_path = data_path
         self.environment = environment
@@ -330,7 +336,9 @@ class ScenarioRunner:
 
     def run_scenario(self) -> None:
         with Janitor() as nursery:
-            self.node_controller = NodeController(self, self.definition.nodes, nursery)
+            self.node_controller = NodeController(
+                self, self.definition.nodes, nursery, delete_snapshots=self.delete_snapshots
+            )
             self.node_controller.initialize_nodes()
 
             try:
@@ -591,13 +599,12 @@ class ScenarioRunner:
         - Deploy a new token if neither of the above options is used.
         """
         token_definition = self.definition.token
-        reuse_token_from_file = token_definition.reuse_token
-        token_info_path = self.data_path.joinpath("token.info")
+        reuse_token_from_file = token_definition.can_reuse_token
 
         if token_definition.address:
             token_address = to_canonical_address(token_definition.address)
-        elif reuse_token_from_file and token_info_path.exists():
-            token_details = load_token_configuration_from_file(str(token_info_path))
+        elif reuse_token_from_file:
+            token_details = load_token_configuration_from_file(token_definition.token_file)
             token_address = to_canonical_address(token_details["address"])
         else:
             contract_data = proxy_manager.contract_manager.get_contract(CONTRACT_CUSTOM_TOKEN)
@@ -613,7 +620,7 @@ class ScenarioRunner:
             )
             token_address = to_canonical_address(contract.address)
 
-            if reuse_token_from_file:
+            if token_definition.should_reuse_token:
                 details = TokenDetails(
                     {
                         "name": token_definition.name,
@@ -621,7 +628,7 @@ class ScenarioRunner:
                         "block": receipt["blockNumber"],
                     }
                 )
-                save_token_configuration_to_file(str(token_info_path), details)
+                save_token_configuration_to_file(token_definition.token_file, details)
 
         return proxy_manager.custom_token(TokenAddress(token_address), "latest")
 

--- a/scenario_player/tasks/api_base.py
+++ b/scenario_player/tasks/api_base.py
@@ -47,7 +47,9 @@ class RESTAPIActionTask(Task):
         except (ReadTimeout, ConnectTimeout) as ex:
             self._handle_timeout(ex)
         except RequestException as ex:
-            raise RESTAPIError(f"Error performing REST-API call: {self._name}") from ex
+            raise RESTAPIError(
+                f"Error performing REST-API call: {self._name}"  # pylint: disable=no-member
+            ) from ex
         if not self._http_status_re.match(str(resp.status_code)):
             raise RESTAPIStatusMismatchError(
                 f'HTTP status code "{resp.status_code}" while fetching {url}. '

--- a/scenario_player/tasks/channels.py
+++ b/scenario_player/tasks/channels.py
@@ -94,9 +94,7 @@ class TransferTask(ChannelActionTask):
     _method = "post"
     _transfer_count = 0
 
-    def __init__(
-        self, runner: scenario_runner.ScenarioRunner, config: Any, parent=None, abort_on_fail=True
-    ) -> None:
+    def __init__(self, runner: scenario_runner.ScenarioRunner, config: Any, parent=None) -> None:
         super().__init__(runner, config, parent)
         # Unique transfer identifier
         self.__class__._transfer_count += 1

--- a/scenario_player/tasks/raiden_api.py
+++ b/scenario_player/tasks/raiden_api.py
@@ -9,8 +9,8 @@ log = structlog.get_logger(__name__)
 class RaidenAPIActionTask(RESTAPIActionTask):
     def _handle_timeout(self, ex: Exception):
         raise TransferFailed(
-            f"{self._name.replace('_', ' ').title()} didn't complete within "
-            f"timeout of {self._timeout}"
+            f"{self._name.replace('_', ' ').title()} didn't complete "  # pylint: disable=no-member
+            f"within timeout of {self._timeout}"
         ) from ex
 
     @property

--- a/scenario_player/ui.py
+++ b/scenario_player/ui.py
@@ -33,6 +33,7 @@ PALETTE = [
     ("task_state_errored", "dark red", "default"),
     ("task_duration", "dark magenta", "default"),
     ("task_name", "dark blue", "default"),
+    ("task_info", "light blue", "default"),
 ]
 log = structlog.get_logger(__name__)
 

--- a/scenario_player/utils/configuration/nodes.py
+++ b/scenario_player/utils/configuration/nodes.py
@@ -22,6 +22,7 @@ class NodesConfig:
           raiden_version:
           default_options:
             gas_price: fast
+          reuse_accounts:
           node_options:
             0:
               gas_price: slow
@@ -50,6 +51,15 @@ class NodesConfig:
         return self.dict["count"]
 
     @property
+    def reuse_accounts(self) -> bool:
+        """ Should node accounts be re-used across scenario runs. """
+        return self.dict.get("reuse_accounts", False)
+
+    @property
+    def restore_snapshot(self) -> bool:
+        return self.dict.get("restore_snapshot", False)
+
+    @property
     def default_options(self) -> dict:
         """Default CLI flags to pass when starting any node."""
         return self.dict.get("default_options", {})
@@ -71,12 +81,35 @@ class NodesConfig:
 
             * The scenario version is > 1
             * The configuration is not empty
-            * The "count" option is present in the config
-            * If "node_options" is present, make sure its a dict of type `Dict[int, dict]`
+            * The `count` option is present in the config and is an integer
+            * If `reuse_accounts` is present it must be a boolean
+            * If `restore_snapshot` is present it must be a string.
+            * If `restore_snapshot` is not None, `reuse_accounts` must be `True`
+            * If `node_options` is present, make sure its of type `Dict[int, Dict[str, Any]]`
         """
         assert self.dict, "Must specify 'nodes' setting section!"
         assert "count" in self.dict, 'Must specify a "count" setting!'
 
+        assert isinstance(self.count, int), 'Setting "count" must be a number!'
+        if "reuse_accounts" in self.dict:
+            assert isinstance(
+                self.reuse_accounts, bool
+            ), 'Setting "reuse_accounts" must be boolean!'
+
+        if "restore_snapshot" in self.dict:
+            assert isinstance(
+                self.restore_snapshot, bool
+            ), 'Setting "restore_snapshot" must be boolean!'
+
+        if self.restore_snapshot:
+            assert (
+                self.reuse_accounts
+            ), 'Snapshot restoration requires "reuse_accounts" to be enabled!'
+
         if self.node_options:
-            assert all(isinstance(k, int) for k in self.node_options.keys())
-            assert all(isinstance(v, dict) for v in self.node_options.values())
+            msg = (
+                "node_options must be a dictionary of integer node-ids "
+                "to a dictionary of node options"
+            )
+            assert all(isinstance(k, int) for k in self.node_options.keys()), msg
+            assert all(isinstance(v, dict) for v in self.node_options.values()), msg

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -27,6 +27,7 @@ log = structlog.get_logger(__name__)
 
 @dataclass
 class EnvironmentConfig:
+    environment_file_name: str
     environment_type: Union[Literal["production"], Literal["development"]]
     matrix_servers: Sequence[Union[URI, Literal["auto"]]]
     pfs_with_fee: URI

--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -42,10 +42,10 @@ class DummyStream:
 class MutuallyExclusiveOption(click.Option):
     def __init__(self, *args, **kwargs):
         self.mutually_exclusive = set(kwargs.pop("mutually_exclusive", []))
-        help = kwargs.get("help", "")
+        help_ = kwargs.get("help", "")
         if self.mutually_exclusive:
             ex_str = ", ".join(self.mutually_exclusive)
-            kwargs["help"] = help + (
+            kwargs["help"] = help_ + (
                 " NOTE: This argument is mutually exclusive with " " arguments: [" + ex_str + "]."
             )
         super(MutuallyExclusiveOption, self).__init__(*args, **kwargs)

--- a/scenario_player/utils/reclaim.py
+++ b/scenario_player/utils/reclaim.py
@@ -149,7 +149,7 @@ def withdraw_from_udc(
 
     log.info("Checking chain for deposits in UserDeposit contact")
     for node in reclamation_candidates:
-        (userdeposit_proxy, user_token_proxy) = get_udc_and_corresponding_token_from_dependencies(
+        (userdeposit_proxy, _) = get_udc_and_corresponding_token_from_dependencies(
             chain_id=chain_id, proxy_manager=node.get_proxy_manager(web3, deploy)
         )
 
@@ -181,7 +181,7 @@ def withdraw_from_udc(
     for address, (ready_at_block, amount) in planned_withdraws.items():
         candidate = [c for c in reclamation_candidates if c.address == address][0]
         proxy_manager = candidate.get_proxy_manager(web3, deploy)
-        (userdeposit_proxy, user_token_proxy) = get_udc_and_corresponding_token_from_dependencies(
+        (userdeposit_proxy, _) = get_udc_and_corresponding_token_from_dependencies(
             chain_id=chain_id, proxy_manager=proxy_manager
         )
         # FIXME: Something is off with the block numbers, adding 20 to work around.

--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import cast
 
 import gevent
@@ -127,7 +128,7 @@ def userdeposit_maybe_deposit(
         )
 
 
-def load_token_configuration_from_file(token_file: str) -> TokenDetails:
+def load_token_configuration_from_file(token_file: Path) -> TokenDetails:
     """Load token configuration from disk.
 
     The file contents should be at least::
@@ -147,8 +148,7 @@ def load_token_configuration_from_file(token_file: str) -> TokenDetails:
         exists for it in the data-path.
     """
     try:
-        with open(token_file) as handler:
-            token_data = json.load(handler)
+        token_data = json.loads(token_file.read_text())
     except json.JSONDecodeError as e:
         raise TokenFileError("Token data file corrupted!") from e
     except FileNotFoundError as e:
@@ -160,7 +160,7 @@ def load_token_configuration_from_file(token_file: str) -> TokenDetails:
     return cast(TokenDetails, token_data)
 
 
-def save_token_configuration_to_file(token_file: str, token_data: TokenDetails) -> None:
+def save_token_configuration_to_file(token_file: Path, token_data: TokenDetails) -> None:
     """Save information of the token deployment to a file.
 
     The file will be JSON encoded and have the following format::
@@ -169,5 +169,4 @@ def save_token_configuration_to_file(token_file: str, token_data: TokenDetails) 
 
 
     """
-    with open(token_file) as handler:
-        json.dump(token_data, handler)
+    token_file.write_text(json.dumps(token_data))

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -14,6 +14,7 @@ from scenario_player.utils.configuration.settings import (
 
 dummy_env = EnvironmentConfig(
     pfs_fee=FeeAmount(100),
+    environment_file_name="tests",
     environment_type="development",
     matrix_servers=[],
     transfer_token=TokenAddress(bytes([1] * 20)),

--- a/tests/unittests/utils/configuration/test_token.py
+++ b/tests/unittests/utils/configuration/test_token.py
@@ -44,7 +44,7 @@ class TestTokenConfig:
 
         config = TokenConfig(minimal_definition_dict, token_info_path)
 
-        assert config.reuse_token == (reuse and exists)
+        assert config.can_reuse_token == (reuse and exists)
 
     def test_symbol_property_uses_token_id_to_generate_symbol_if_not_given_in_config(
         self, minimal_definition_dict, token_info_path

--- a/tests/unittests/utils/conftest.py
+++ b/tests/unittests/utils/conftest.py
@@ -2,10 +2,11 @@ import json
 
 import pytest
 
+
 @pytest.fixture
 def token_info_path(tmp_path):
     path = tmp_path.joinpath("token.info")
     path.touch()
     with path.open("w") as f:
-        json.dump({"token_name": "my_token", "address": "my_address", "block": 0}, f)
+        json.dump({"name": "my_token", "address": "my_address", "block": 0}, f)
     return path


### PR DESCRIPTION
This adds the following features:
- Re-enables the possibility to reuse node accounts between runs (as a per scenario option)
- Adds a "snapshot" feature that allows to restore the node datadirs to a previous state. 

Additionally this fixes the TUI that had been broken by a previous refactoring.