### PR TITLE
Disable codecov.io for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,6 @@ commands:
       - run:
           name: Run test harness.
           command: make test
-      - run:
-          name: Upload coverage report
-          command: codecov
 
   run_smoketests:
     description: Execute Smoketests to verify build.


### PR DESCRIPTION
At the current state of test coverage and with the current shortcomings of codecov.io reporting it makes more sense not to report (and avoid misleading fail markers).