### PR TITLE
Re-enable smoketest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
       - setup-job
       - lint_codebase
       - run_test_harness
-      # - run_smoketests
+      - run_smoketests
       - store_env
 
   # Publish a wheel and tarball of the Scenario Player to pypi.


### PR DESCRIPTION
Part of #491

The account from `.circleci/smoketest.keystore` is funded and smoketests can be re-enabled.