### PR TITLE
Fix address access in AssertBlockchainEventsTask

### DIFF
--- a/scenario_player/tasks/blockchain.py
+++ b/scenario_player/tasks/blockchain.py
@@ -140,11 +140,6 @@ class AssertBlockchainEventsTask(Task):
         self.event_name = config["event_name"]
         self.num_events = config["num_events"]
         self.event_args: Dict[str, Any] = config.get("event_args", {}).copy()
-        for key, value in self.event_args.items():
-            if "participant" in key:
-                if isinstance(value, int) or (isinstance(value, str) and value.isnumeric()):
-                    # Replace node index with eth address
-                    self.event_args[key] = self._runner.get_node_address(int(value))
 
         self.web3 = self._runner.client.web3
 
@@ -180,6 +175,12 @@ class AssertBlockchainEventsTask(Task):
         events = [e for e in events if e["event"] == self.event_name]
 
         if self.event_args:
+            for key, value in self.event_args.items():
+                if "participant" in key:
+                    if isinstance(value, int) or (isinstance(value, str) and value.isnumeric()):
+                        # Replace node index with eth address
+                        self.event_args[key] = self._runner.get_node_address(int(value))
+
             event_args_items = self.event_args.items()
             # Filter the events by the given event args.
             # `.items()` produces a set like object which supports intersection (`&`)


### PR DESCRIPTION
The node_controller only exists while running the scenario, not when
instantiating the tasks. This was different before
https://github.com/raiden-network/scenario-player/pull/514.

This fixes the following error from the latest scenario runs:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/scenario_player/main.py", line 250, in run
    account, auth, chain, data_path, scenario_file, notify_tasks_callable
  File "/usr/local/lib/python3.7/site-packages/scenario_player/main.py", line 310, in orchestrate
    scenario_runner = ScenarioRunner(*scenario_runner_args)
  File "/usr/local/lib/python3.7/site-packages/scenario_player/runner.py", line 119, in __init__
    self.root_task = task_class(runner=self, config=task_config)
  File "/usr/local/lib/python3.7/site-packages/scenario_player/tasks/execution.py", line 34, in __init__
    task_class(runner=self._runner, config=task_config, parent=self)
  File "/usr/local/lib/python3.7/site-packages/scenario_player/tasks/blockchain.py", line 147, in __init__
    self.event_args[key] = self._runner.get_node_address(int(value))
  File "/usr/local/lib/python3.7/site-packages/scenario_player/runner.py", line 446, in get_node_address
    return self.node_controller[index].address
AttributeError: 'ScenarioRunner' object has no attribute 'node_controller'
```