### PR TITLE
Don't catch GreenletExit

### DIFF
--- a/scenario_player/tasks/api_base.py
+++ b/scenario_player/tasks/api_base.py
@@ -18,13 +18,9 @@ class RESTAPIActionTask(Task):
     _expected_http_status: Union[int, str] = "2.."
 
     def __init__(
-        self,
-        runner: scenario_runner.ScenarioRunner,
-        config: Any,
-        parent: "Task" = None,
-        abort_on_fail=True,
+        self, runner: scenario_runner.ScenarioRunner, config: Any, parent: "Task" = None
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
 
         self._expected_http_status = config.get("expected_http_status", self._expected_http_status)
         self._http_status_re = re.compile(f"^{self._expected_http_status}$")

--- a/scenario_player/tasks/blockchain.py
+++ b/scenario_player/tasks/blockchain.py
@@ -121,13 +121,9 @@ class AssertBlockchainEventsTask(Task):
     _name = "assert_events"
 
     def __init__(
-        self,
-        runner: scenario_runner.ScenarioRunner,
-        config: Any,
-        parent: "Task" = None,
-        abort_on_fail: bool = True,
+        self, runner: scenario_runner.ScenarioRunner, config: Any, parent: "Task" = None
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
 
         required_keys = ["contract_name", "event_name", "num_events"]
         all_required_options_provided = all(key in config.keys() for key in required_keys)
@@ -198,13 +194,9 @@ class AssertMSClaimTask(Task):
     _name = "assert_ms_claim"
 
     def __init__(
-        self,
-        runner: scenario_runner.ScenarioRunner,
-        config: Any,
-        parent: Task = None,
-        abort_on_fail: bool = True,
+        self, runner: scenario_runner.ScenarioRunner, config: Any, parent: Task = None
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
 
         required_keys = {"channel_info_key"}
         if not required_keys.issubset(config.keys()):

--- a/scenario_player/tasks/channels.py
+++ b/scenario_player/tasks/channels.py
@@ -95,7 +95,7 @@ class TransferTask(ChannelActionTask):
     def __init__(
         self, runner: scenario_runner.ScenarioRunner, config: Any, parent=None, abort_on_fail=True
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
         # Unique transfer identifier
         self.__class__._transfer_count += 1
         if str(self._config.get("identifier", "")).lower() == "generate":
@@ -123,13 +123,9 @@ class StoreChannelInfoTask(ChannelActionTask):
     _method = "get"
 
     def __init__(
-        self,
-        runner: scenario_runner.ScenarioRunner,
-        config: Any,
-        parent: Task = None,
-        abort_on_fail=True,
+        self, runner: scenario_runner.ScenarioRunner, config: Any, parent: Task = None
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
         if "key" not in config:
             raise ScenarioError('Required config "key" not found')
 

--- a/scenario_player/tasks/execution.py
+++ b/scenario_player/tasks/execution.py
@@ -16,13 +16,9 @@ class SerialTask(Task):
     _name = "serial"
 
     def __init__(
-        self,
-        runner: scenario_runner.ScenarioRunner,
-        config: Any,
-        parent: "Task" = None,
-        abort_on_fail=True,
+        self, runner: scenario_runner.ScenarioRunner, config: Any, parent: "Task" = None
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
         self._name = config.get("name")
 
         self._tasks: List = []

--- a/scenario_player/tasks/services.py
+++ b/scenario_player/tasks/services.py
@@ -316,13 +316,9 @@ class AssertPFSIoUTask(RESTAPIActionTask):
     _url_template = "{pfs_url}/api/v1/_debug/ious/{source_address}"
 
     def __init__(
-        self,
-        runner: scenario_runner.ScenarioRunner,
-        config: Any,
-        parent: Task = None,
-        abort_on_fail: bool = True,
+        self, runner: scenario_runner.ScenarioRunner, config: Any, parent: Task = None
     ) -> None:
-        super().__init__(runner, config, parent, abort_on_fail)
+        super().__init__(runner, config, parent)
 
         if "source" not in config:
             raise ScenarioError("Not all required keys provided. Required: source ")


### PR DESCRIPTION
Otherwise we can't kill the tasks when we want to exit.

Also catch `Exception` instead of `BaseException`, since this is usually
the right thing to do and there is no reason given for catching
`BaseException`.