### PR TITLE
Fix token deployment when no token is given

### DIFF
--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -23,7 +23,7 @@ TokenDetails = TypedDict("TokenDetails", {"name": str, "address": ChecksumAddres
 
 
 def token_maybe_mint(
-    token_proxy: CustomToken, target_address, minimum_balance: int, maximum_balance: int
+    token_proxy: CustomToken, target_address: Address, minimum_balance: int, maximum_balance: int
 ) -> None:
     current_balance = token_proxy.balance_of(target_address)
 


### PR DESCRIPTION
Fixes multiple problems during token creation.
- Deploy CustomToken, so one can call `mintFor`
- Fix usage of invalid token_address
- Fix parameter order
- Create proper proxy for new token contract

Fixes #526