### PR TITLE
Upgrade matrix-synapse dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "flake8-tuple==0.2.13",
     "flake8==3.7.5",
     "isort==4.3.16",
-    "matrix-synapse==1.5.1",
+    "matrix-synapse==1.10.1",
     "mypy==0.761",
     "pytest==4.5.0",
     "pytest-cov",


### PR DESCRIPTION
This upgrades the `matrix-synapse` dependency to be in sync with `raiden-network/raiden`. Merge this only after https://github.com/raiden-network/raiden/pull/5983