### PR TITLE
Use `--eth-rpc-endpoint` when reclaiming tokens

### DIFF
--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -144,15 +144,17 @@ def data_path_option(func):
     return wrapper
 
 
-def chain_option(func):
-    """Decorator for adding '--chain' to subcommands."""
+def eth_rpc_option(func):
+    """Decorator for adding '--eth-rpc-endpoint' to subcommands."""
 
     @click.option(
-        "--chain",
-        "chain",
+        "--eth-rpc-endpoint",
         multiple=False,
         required=True,
-        help="Chain name to eth rpc url mapping.",
+        help=(
+            '"host:port" address of ethereum JSON-RPC server. '
+            "Accepts a protocol prefix (http:// or https://) with optional port."
+        ),
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -429,22 +431,23 @@ class ScenarioUIManager:
     help="Minimum account non-usage age before reclaiming eth. In hours.",
 )
 @key_password_options
-@chain_option
+@eth_rpc_option
 @data_path_option
 @click.pass_context
-def reclaim_eth(ctx, min_age, password, password_file, keystore_file, chain, data_path):
-    log.info("start cmd", chain=chain)
+def reclaim_eth(ctx, min_age, password, password_file, keystore_file, eth_rpc_endpoint, data_path):
+    log.info("start cmd")
 
     data_path = Path(data_path)
-    log.info("using chain", chain=chain)
-
     password = get_password(password, password_file)
     account = get_account(keystore_file, password)
 
     configure_logging_for_subcommand(construct_log_file_name("reclaim-eth", data_path))
-    log.info("start reclaim", chain=chain)
+    log.info("start reclaim", eth_rpc_endpoint=eth_rpc_endpoint)
     scenario_player.utils.reclaim_eth(
-        min_age_hours=min_age, chain_str=chain, data_path=data_path, account=account
+        min_age_hours=min_age,
+        eth_rpc_endpoint=eth_rpc_endpoint,
+        data_path=data_path,
+        account=account,
     )
 
 

--- a/tests/unittests/cli/test_cli.py
+++ b/tests/unittests/cli/test_cli.py
@@ -118,7 +118,7 @@ class TestDataPathBehavior:
         result = runner.invoke(
             main.reclaim_eth,
             f"--data-path {path_arg} "
-            "--chain smoketest:http://localhost:12345 "
+            "--eth-rpc-endpoint http://localhost:12345 "
             f"--password-file {KEYSTORE_PATH.joinpath('password')} "
             f"--keystore-file {KEYSTORE_PATH.joinpath('UTC--1')} ",
         )


### PR DESCRIPTION
This replaces the old `--chain` parameter. I plan to call the nightly SP
runs with only an environment file as parameters.  When doing this, we
don't have chain names as input, anymore, but only RPC addresses.

Downside:
* Only one chain can be reclaimed at the same time

Upsides:
* More consistent with raiden
* Slightly simpler code
* We never really used multiple chains, so I'm not sure it works as intended.
  Especially since passing multiple chains is disallowed by `multiple=False`.