### PR TITLE
`claim` now takes environment file, like `run`

### DIFF
--- a/tests/unittests/cli/test_cli.py
+++ b/tests/unittests/cli/test_cli.py
@@ -118,7 +118,6 @@ class TestDataPathBehavior:
         result = runner.invoke(
             main.reclaim_eth,
             f"--data-path {path_arg} "
-            "--eth-rpc-endpoint http://localhost:12345 "
             f"--password-file {KEYSTORE_PATH.joinpath('password')} "
             f"--keystore-file {KEYSTORE_PATH.joinpath('UTC--1')} ",
         )


### PR DESCRIPTION
For claiming, we only need the eth-rpc-endpoint from the environment
file. This is the reason why I previously used and `--eth-rpc-endpoint`
option, like Raiden does. But I realized that consistency with the `run`
command is more useful than being minimal and consistent with Raiden in
this case.