### PR TITLE
Avoid inconsistent RECLAIM_MIN_BALANCE

### DIFF
--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -148,7 +148,8 @@ def reclaim_eth(
 
     txs = []
     reclaim_amount = 0
-    reclaim_tx_cost = web3.eth.gasPrice * VALUE_TX_GAS_COST
+    gas_price = web3.eth.gasPrice
+    reclaim_tx_cost = gas_price * VALUE_TX_GAS_COST
 
     log.info("Checking chain")
     for address, keyfile_content in address_to_keyfile.items():
@@ -165,7 +166,7 @@ def reclaim_eth(
             txs.append(
                 client.transact(
                     EthTransfer(
-                        to_address=account.address, value=drain_amount, gas_price=web3.eth.gasPrice
+                        to_address=account.address, value=drain_amount, gas_price=gas_price
                     )
                 )
             )

--- a/tests/unittests/cli/test_cli.py
+++ b/tests/unittests/cli/test_cli.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -111,15 +111,18 @@ class TestVersionInformation:
 
 
 class TestDataPathBehavior:
-    def test_reclaim_eth_data_path(self, runner, tmpdir):
+    @patch("scenario_player.utils.legacy.Web3")
+    def test_reclaim_eth_data_path(self, web3_mock, runner, tmpdir):
         """Regression test, to make sure '--data-path' is respected for
         'reclaim-eth' subcommand."""
+        web3_mock.eth.gasCost = 1
         path_arg = str(tmpdir.mkdir("use_this"))
         result = runner.invoke(
             main.reclaim_eth,
             f"--data-path {path_arg} "
             f"--password-file {KEYSTORE_PATH.joinpath('password')} "
             f"--keystore-file {KEYSTORE_PATH.joinpath('UTC--1')} ",
+            catch_exceptions=False,
         )
         print(result.output)
         assert result.exit_code == 0


### PR DESCRIPTION
Before this commit, `RECLAIM_MIN_BALANCE` was not the same as the tx
cost for the reclaim. If it's bigger, we would not reclaim some small
funds. If it's smaller, we would get an error because we would try to
reclaim a negative value.

The obvious fix is to use the tx cost as the minimum reclaim balance.