### PR TITLE
Withdraw and reclaim ERC20

### DIFF
--- a/scenario_player/constants.py
+++ b/scenario_player/constants.py
@@ -9,7 +9,7 @@ NODE_ACCOUNT_BALANCE_MIN = 15 * 10 ** 16  # := 0.15 Eth
 NODE_ACCOUNT_BALANCE_FUND = 3 * 10 ** 17  # := 0.3 Eth
 TIMEOUT = 200
 API_URL_TOKEN_NETWORK_ADDRESS = "{protocol}://{target_host}/api/v1/tokens/{token_address}"
-MAX_RAIDEN_STARTUP_TIME = 100  # seconds
+MAX_RAIDEN_STARTUP_TIME = 2000  # seconds
 
 #: Available gas price strategies selectable by passing their key to the
 #: settings.gas_price config option in the scenario definition.

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -429,6 +429,7 @@ class ScenarioUIManager:
 )
 @click.option(
     "--reclaim-token",
+    "reclaim_tokens",
     multiple=True,
     type=AddressType(),
     help="ERC20 token address for which tokens should also be reclaimed",
@@ -446,7 +447,7 @@ class ScenarioUIManager:
 def reclaim_eth(
     ctx,
     min_age,
-    reclaim_token: List[TokenAddress],
+    reclaim_tokens: List[TokenAddress],
     withdraw_from_udc: bool,
     password,
     password_file,
@@ -475,7 +476,7 @@ def reclaim_eth(
             account=account,
         )
 
-    for token_address in reclaim_token:
+    for token_address in reclaim_tokens:
         log.info(
             "start ERC20 token reclaim",
             token=to_checksum_address(token_address),

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -465,7 +465,7 @@ def reclaim_eth(
     configure_logging_for_subcommand(construct_log_file_name("reclaim-eth", data_path))
 
     reclamation_candidates = get_reclamation_candidates(data_path, min_age)
-    log.info("Reclaiming candidates", addresses=list(reclamation_candidates.keys()))
+    log.info("Reclaiming candidates", addresses=list(c.address for c in reclamation_candidates))
 
     if withdraw_from_udc:
         scenario_player.utils.withdraw_from_udc(

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -12,7 +12,7 @@ from io import StringIO
 from itertools import cycle, islice
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import IO
+from typing import IO, List
 
 import click
 import gevent
@@ -23,7 +23,12 @@ from eth_typing import HexStr
 from eth_utils import to_checksum_address
 from gevent.event import Event
 from raiden_contracts.constants import CHAINNAME_TO_ID
-from raiden_contracts.contract_manager import DeployedContract, DeployedContracts
+from raiden_contracts.contract_manager import (
+    ContractManager,
+    DeployedContract,
+    DeployedContracts,
+    contracts_precompiled_path,
+)
 from urwid import ExitMainLoop
 
 import scenario_player.utils
@@ -31,8 +36,8 @@ from raiden.accounts import Account
 from raiden.constants import Environment, EthClient
 from raiden.log_config import _FIRST_PARTY_PACKAGES, configure_logging
 from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS, RAIDEN_CONTRACT_VERSION
-from raiden.utils.cli import EnumChoiceType, get_matrix_servers, option
-from raiden.utils.typing import TYPE_CHECKING, Any, AnyStr, Dict, Optional
+from raiden.utils.cli import AddressType, EnumChoiceType, get_matrix_servers, option
+from raiden.utils.typing import TYPE_CHECKING, Any, AnyStr, Dict, Optional, TokenAddress
 from scenario_player import __version__, tasks
 from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.exceptions.cli import WrongPassword
@@ -40,7 +45,7 @@ from scenario_player.runner import ScenarioRunner
 from scenario_player.tasks.base import collect_tasks
 from scenario_player.ui import ScenarioUI, attach_urwid_logbuffer
 from scenario_player.utils import DummyStream, post_task_state_to_rc
-from scenario_player.utils.legacy import MutuallyExclusiveOption
+from scenario_player.utils.legacy import MutuallyExclusiveOption, get_reclamation_candidates
 from scenario_player.utils.version import get_complete_spec
 
 if TYPE_CHECKING:
@@ -422,24 +427,72 @@ class ScenarioUIManager:
     show_default=True,
     help="Minimum account non-usage age before reclaiming eth. In hours.",
 )
+@click.option(
+    "--reclaim-token",
+    multiple=True,
+    type=AddressType(),
+    help="ERC20 token address for which tokens should also be reclaimed",
+)
+@click.option(
+    "--withdraw-from-udc",
+    is_flag=True,
+    default=False,
+    help="Withdraw and reclaim tokens deposited in the UserDeposit contract",
+)
 @key_password_options
 @environment_option
 @data_path_option
 @click.pass_context
-def reclaim_eth(ctx, min_age, password, password_file, keystore_file, environment, data_path):
-    log.info("start cmd")
+def reclaim_eth(
+    ctx,
+    min_age,
+    reclaim_token: List[TokenAddress],
+    withdraw_from_udc: bool,
+    password,
+    password_file,
+    keystore_file,
+    environment,
+    data_path,
+):
+    eth_rpc_endpoint = environment["eth_rpc_endpoint"]
+    log.info("start cmd", eth_rpc_endpoint=eth_rpc_endpoint)
 
     data_path = Path(data_path)
     password = get_password(password, password_file)
     account = get_account(keystore_file, password)
-    eth_rpc_endpoint = environment["eth_rpc_endpoint"]
+    contract_manager = ContractManager(contracts_precompiled_path(RAIDEN_CONTRACT_VERSION))
 
     configure_logging_for_subcommand(construct_log_file_name("reclaim-eth", data_path))
-    log.info("start reclaim", eth_rpc_endpoint=eth_rpc_endpoint)
+
+    reclamation_candidates = get_reclamation_candidates(data_path, min_age)
+    log.info("Reclaiming candidates", addresses=list(reclamation_candidates.keys()))
+
+    if withdraw_from_udc:
+        scenario_player.utils.withdraw_from_udc(
+            reclamation_candidates=reclamation_candidates,
+            contract_manager=contract_manager,
+            eth_rpc_endpoint=eth_rpc_endpoint,
+            account=account,
+        )
+
+    for token_address in reclaim_token:
+        log.info(
+            "start ERC20 token reclaim",
+            token=to_checksum_address(token_address),
+            eth_rpc_endpoint=eth_rpc_endpoint,
+        )
+        scenario_player.utils.reclaim_erc20(
+            reclamation_candidates=reclamation_candidates,
+            token_address=token_address,
+            contract_manager=contract_manager,
+            eth_rpc_endpoint=eth_rpc_endpoint,
+            account=account,
+        )
+
+    log.info("start eth reclaim", eth_rpc_endpoint=eth_rpc_endpoint)
     scenario_player.utils.reclaim_eth(
-        min_age_hours=min_age,
+        reclamation_candidates=reclamation_candidates,
         eth_rpc_endpoint=eth_rpc_endpoint,
-        data_path=data_path,
         account=account,
     )
 

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -102,19 +102,13 @@ def wait_for_nodes_to_be_ready(node_runners, session):
 
 
 def get_udc_and_corresponding_token_from_dependencies(
-    udc_settings: UDCSettingsConfig, settings: SettingsConfig, proxy_manager: ProxyManager
+    udc_address: Optional[ChecksumAddress], chain_id: ChainID, proxy_manager: ProxyManager
 ) -> Tuple[UserDeposit, CustomToken]:
     """ Return contract proxies for the UserDepositContract and associated token.
 
     This will return a proxy to the `UserDeposit` contract as determined by the
     **local** Raiden depedency.
     """
-    assert udc_settings.enable
-    chain_id = settings.chain_id
-    assert chain_id, "Missing configuration, either set udc_address or the chain_id"
-
-    udc_address = udc_settings.address
-
     if udc_address is None:
 
         contracts = get_contracts_deployment_info(chain_id, version=RAIDEN_CONTRACT_VERSION)
@@ -439,7 +433,9 @@ class ScenarioRunner:
                 userdeposit_proxy,
                 user_token_proxy,
             ) = get_udc_and_corresponding_token_from_dependencies(
-                udc_settings=udc_settings, settings=settings, proxy_manager=proxy_manager
+                udc_address=udc_settings.address,
+                chain_id=settings.chain_id,
+                proxy_manager=proxy_manager,
             )
 
             log.debug("Minting utility tokens and /scheduling/ transfers to the nodes")

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -15,21 +15,15 @@ from raiden_contracts.constants import (
     CHAINNAME_TO_ID,
     CONTRACT_CUSTOM_TOKEN,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
-    CONTRACT_USER_DEPOSIT,
 )
-from raiden_contracts.contract_manager import (
-    ContractManager,
-    DeployedContracts,
-    contracts_precompiled_path,
-    get_contracts_deployment_info,
-)
+from raiden_contracts.contract_manager import DeployedContracts, get_contracts_deployment_info
 from requests import HTTPError, Session
 from web3 import HTTPProvider, Web3
 
 from raiden.accounts import Account
 from raiden.constants import UINT256_MAX
 from raiden.network.proxies.custom_token import CustomToken
-from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
+from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.network.rpc.client import JSONRPCClient
@@ -38,13 +32,11 @@ from raiden.utils.formatting import to_canonical_address
 from raiden.utils.nursery import Janitor
 from raiden.utils.typing import (
     Address,
-    BlockNumber,
     ChainID,
     TokenAddress,
     TokenAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
-    UserDepositAddress,
 )
 from scenario_player.constants import (
     API_URL_TOKEN_NETWORK_ADDRESS,
@@ -60,6 +52,10 @@ from scenario_player.exceptions.legacy import TokenNetworkDiscoveryTimeout
 from scenario_player.node_support import NodeController, RaidenReleaseKeeper
 from scenario_player.utils import TimeOutHTTPAdapter
 from scenario_player.utils.configuration.settings import SettingsConfig, UDCSettingsConfig
+from scenario_player.utils.contracts import (
+    get_proxy_manager,
+    get_udc_and_corresponding_token_from_dependencies,
+)
 from scenario_player.utils.token import (
     TokenDetails,
     eth_maybe_transfer,
@@ -99,53 +95,6 @@ def wait_for_nodes_to_be_ready(node_runners, session):
                 except requests.exceptions.RequestException:
                     pass
                 gevent.sleep(0.5)
-
-
-def get_proxy_manager(client: JSONRPCClient, deploy: DeployedContracts) -> ProxyManager:
-    contract_manager = ContractManager(contracts_precompiled_path(RAIDEN_CONTRACT_VERSION))
-
-    assert "contracts" in deploy, deploy
-    token_network_deployment_details = deploy["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY]
-    deployed_at = token_network_deployment_details["block_number"]
-    token_network_registry_deployed_at = BlockNumber(deployed_at)
-
-    return ProxyManager(
-        client,
-        contract_manager,
-        ProxyManagerMetadata(
-            token_network_registry_deployed_at=token_network_registry_deployed_at,
-            filters_start_at=token_network_registry_deployed_at,
-        ),
-    )
-
-
-def get_udc_and_corresponding_token_from_dependencies(
-    udc_address: Optional[ChecksumAddress], chain_id: ChainID, proxy_manager: ProxyManager
-) -> Tuple[UserDeposit, CustomToken]:
-    """ Return contract proxies for the UserDepositContract and associated token.
-
-    This will return a proxy to the `UserDeposit` contract as determined by the
-    **local** Raiden depedency.
-    """
-    if udc_address is None:
-
-        contracts = get_contracts_deployment_info(chain_id, version=RAIDEN_CONTRACT_VERSION)
-
-        msg = (
-            f"invalid chain_id, {chain_id} is not available for version {RAIDEN_CONTRACT_VERSION}"
-        )
-        assert contracts, msg
-
-        udc_address = contracts["contracts"][CONTRACT_USER_DEPOSIT]["address"]
-
-    userdeposit_proxy = proxy_manager.user_deposit(
-        UserDepositAddress(to_canonical_address(udc_address)), "latest"
-    )
-
-    token_address = userdeposit_proxy.token_address("latest")
-    user_token_proxy = proxy_manager.custom_token(token_address, "latest")
-
-    return userdeposit_proxy, user_token_proxy
 
 
 def get_token_network_registry_from_dependencies(

--- a/scenario_player/utils/__init__.py
+++ b/scenario_player/utils/__init__.py
@@ -3,9 +3,11 @@ from scenario_player.utils.legacy import (
     DummyStream,
     TimeOutHTTPAdapter,
     post_task_state_to_rc,
+    reclaim_erc20,
     reclaim_eth,
     send_rc_message,
     wait_for_txs,
+    withdraw_from_udc,
 )
 
 __all__ = [
@@ -14,6 +16,8 @@ __all__ = [
     "DummyStream",
     "wait_for_txs",
     "reclaim_eth",
+    "reclaim_erc20",
+    "withdraw_from_udc",
     "post_task_state_to_rc",
     "send_rc_message",
 ]

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Union
 import structlog
 from eth_typing import URI
 
-from raiden.utils.typing import ChainID
+from raiden.utils.typing import ChainID, ChecksumAddress
 from scenario_player.constants import GAS_STRATEGIES, TIMEOUT
 from scenario_player.exceptions.config import (
     ScenarioConfigurationError,
@@ -138,11 +138,12 @@ class UDCSettingsConfig:
         return flag
 
     @property
-    def address(self) -> Union[str, None]:
+    def address(self) -> Optional[ChecksumAddress]:
         address = self.dict.get("address")
-        assert isinstance(address, (str, type(None)))
+        if address is None:
+            return None
 
-        return address
+        return ChecksumAddress(address)
 
 
 class ServiceSettingsConfig:

--- a/scenario_player/utils/contracts.py
+++ b/scenario_player/utils/contracts.py
@@ -1,0 +1,65 @@
+from typing import Tuple
+
+from eth_typing import ChecksumAddress
+from eth_utils import to_canonical_address
+from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
+from raiden_contracts.contract_manager import (
+    ContractManager,
+    DeployedContracts,
+    contracts_precompiled_path,
+    get_contracts_deployment_info,
+)
+
+from raiden.network.proxies.custom_token import CustomToken
+from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
+from raiden.network.proxies.user_deposit import UserDeposit
+from raiden.network.rpc.client import JSONRPCClient
+from raiden.settings import RAIDEN_CONTRACT_VERSION
+from raiden.utils.typing import BlockNumber, ChainID, UserDepositAddress
+
+
+def get_proxy_manager(client: JSONRPCClient, deploy: DeployedContracts) -> ProxyManager:
+    contract_manager = ContractManager(contracts_precompiled_path(RAIDEN_CONTRACT_VERSION))
+
+    assert "contracts" in deploy, deploy
+    token_network_deployment_details = deploy["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY]
+    deployed_at = token_network_deployment_details["block_number"]
+    token_network_registry_deployed_at = BlockNumber(deployed_at)
+
+    return ProxyManager(
+        client,
+        contract_manager,
+        ProxyManagerMetadata(
+            token_network_registry_deployed_at=token_network_registry_deployed_at,
+            filters_start_at=token_network_registry_deployed_at,
+        ),
+    )
+
+
+def get_udc_and_corresponding_token_from_dependencies(
+    chain_id: ChainID, proxy_manager: ProxyManager, udc_address: ChecksumAddress = None
+) -> Tuple[UserDeposit, CustomToken]:
+    """ Return contract proxies for the UserDepositContract and associated token.
+
+    This will return a proxy to the `UserDeposit` contract as determined by the
+    **local** Raiden depedency.
+    """
+    if udc_address is None:
+
+        contracts = get_contracts_deployment_info(chain_id, version=RAIDEN_CONTRACT_VERSION)
+
+        msg = (
+            f"invalid chain_id, {chain_id} is not available for version {RAIDEN_CONTRACT_VERSION}"
+        )
+        assert contracts, msg
+
+        udc_address = contracts["contracts"][CONTRACT_USER_DEPOSIT]["address"]
+
+    userdeposit_proxy = proxy_manager.user_deposit(
+        UserDepositAddress(to_canonical_address(udc_address)), "latest"
+    )
+
+    token_address = userdeposit_proxy.token_address("latest")
+    user_token_proxy = proxy_manager.custom_token(token_address, "latest")
+
+    return userdeposit_proxy, user_token_proxy

--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -4,23 +4,39 @@ import pathlib
 import time
 from itertools import chain as iter_chain
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
 import requests
 import structlog
 from eth_keyfile import decode_keyfile_json
 from eth_typing import URI
-from eth_utils import encode_hex, to_checksum_address
+from eth_utils import encode_hex, to_canonical_address, to_checksum_address
+from raiden_contracts.contract_manager import ContractManager, get_contracts_deployment_info
 from requests.adapters import HTTPAdapter
 from web3 import HTTPProvider, Web3
 from web3.exceptions import TransactionNotFound
 from web3.types import TxReceipt
 
 from raiden.accounts import Account
+from raiden.exceptions import InsufficientEth
+from raiden.network.proxies.custom_token import CustomToken
+from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.network.rpc.client import EthTransfer, JSONRPCClient, TransactionSent
-from raiden.utils.typing import ChecksumAddress, PrivateKey
+from raiden.settings import RAIDEN_CONTRACT_VERSION
+from raiden.utils.typing import (
+    BlockNumber,
+    ChainID,
+    ChecksumAddress,
+    PrivateKey,
+    TokenAddress,
+    TokenAmount,
+)
 from scenario_player.exceptions import ScenarioTxError
+from scenario_player.utils.contracts import (
+    get_proxy_manager,
+    get_udc_and_corresponding_token_from_dependencies,
+)
 
 VALUE_TX_GAS_COST = 21_000
 
@@ -107,14 +123,8 @@ def wait_for_txs(web3: Web3, transactions: Iterable[TransactionSent], timeout: i
         raise ScenarioTxError(f"Timeout waiting for txhashes: {txhashes_str}")
 
 
-def reclaim_eth(
-    account: Account, eth_rpc_endpoint: URI, data_path: pathlib.Path, min_age_hours: int
-):
-    log.info("Starting eth reclaim", data_path=data_path, eth_rpc_endpoint=eth_rpc_endpoint)
-    web3 = Web3(HTTPProvider(eth_rpc_endpoint))
-
+def get_keyfiles(data_path: pathlib.Path, min_age_hours: int) -> Dict[ChecksumAddress, dict]:
     address_to_keyfile: Dict[ChecksumAddress, dict] = dict()
-    address_to_privkey: Dict[ChecksumAddress, PrivateKey] = dict()
     for node_dir in iter_chain(data_path.glob("**/node_???"), data_path.glob("**/node_*_???")):
         scenario_name: Path = Path(node_dir.parent.name)
         last_run = next(
@@ -143,8 +153,139 @@ def reclaim_eth(
             address = keyfile_content.get("address")
             if address:
                 address_to_keyfile[to_checksum_address(address)] = keyfile_content
+    return address_to_keyfile
 
-    log.info("Reclaiming candidates", addresses=list(address_to_keyfile.keys()))
+
+def get_reclamation_candidates(
+    data_path: pathlib.Path, min_age_hours: int
+) -> Dict[ChecksumAddress, PrivateKey]:
+    address_to_keyfile = get_keyfiles(data_path, min_age_hours)
+    return {
+        address: decode_keyfile_json(keyfile_content, b"")
+        for address, keyfile_content in address_to_keyfile.items()
+    }
+
+
+def withdraw_from_udc(
+    reclamation_candidates: Dict[ChecksumAddress, PrivateKey],
+    contract_manager: ContractManager,
+    account: Account,
+    eth_rpc_endpoint: URI,
+):
+    web3 = Web3(HTTPProvider(eth_rpc_endpoint))
+    chain_id = ChainID(web3.eth.chainId)
+    deploy = get_contracts_deployment_info(chain_id, RAIDEN_CONTRACT_VERSION)
+    assert deploy
+
+    address_to_proxy_manager: Dict[ChecksumAddress, ProxyManager] = dict()
+    planned_withdraws: Dict[ChecksumAddress, Tuple[BlockNumber, TokenAmount]] = dict()
+
+    log.info("Checking chain for deposits in UserDeposit contact")
+    for address, privkey in reclamation_candidates.items():
+        if address not in address_to_proxy_manager:
+            client = JSONRPCClient(web3, privkey)
+            address_to_proxy_manager[address] = get_proxy_manager(client, deploy)
+        proxy_manager = address_to_proxy_manager[address]
+        (userdeposit_proxy, user_token_proxy) = get_udc_and_corresponding_token_from_dependencies(
+            chain_id=chain_id, proxy_manager=proxy_manager
+        )
+
+        balance = userdeposit_proxy.get_total_deposit(to_canonical_address(address), "latest")
+        log.debug("UDC balance", balance=balance, address=address)
+        if balance > 0:
+            drain_amount = TokenAmount(balance)
+            log.info(
+                "Planning withdraw", from_address=address, amount=drain_amount.__format__(",d")
+            )
+            try:
+                ready_at_block = userdeposit_proxy.plan_withdraw(drain_amount, "latest")
+            except InsufficientEth:
+                log.warning("Not sufficient eth in node wallet to withdraw", address=address)
+                continue
+            planned_withdraws[address] = ready_at_block, drain_amount
+
+    if planned_withdraws:
+        log.info(
+            "Withdraws successfully planned, waiting until withdraws are ready",
+            planned_withdraws=planned_withdraws,
+        )
+
+    reclaim_amount = 0
+    for address, (ready_at_block, amount) in planned_withdraws.items():
+        proxy_manager = address_to_proxy_manager[address]
+        (userdeposit_proxy, user_token_proxy) = get_udc_and_corresponding_token_from_dependencies(
+            chain_id=chain_id, proxy_manager=proxy_manager
+        )
+        # FIXME: Something is off with the block numbers, adding 20 to work around.
+        #        See https://github.com/raiden-network/raiden/pull/6091/files#r412234516
+        proxy_manager.client.wait_until_block(BlockNumber(ready_at_block + 20), retry_timeout=10)
+
+        log.info("Withdraw", user_address=address, amount=amount.__format__(",d"))
+        reclaim_amount += amount
+        userdeposit_proxy.withdraw(amount, "latest")
+
+    log.info(
+        "All UDC withdraws finished, now claim the resulting tokens!",
+        withdraw_total=reclaim_amount.__format__(",d"),
+    )
+
+    reclaim_erc20(
+        reclamation_candidates,
+        userdeposit_proxy.token_address("latest"),
+        contract_manager,
+        account,
+        eth_rpc_endpoint,
+    )
+
+
+def reclaim_erc20(
+    reclamation_candidates: Dict[ChecksumAddress, PrivateKey],
+    token_address: TokenAddress,
+    contract_manager: ContractManager,
+    account: Account,
+    eth_rpc_endpoint: URI,
+):
+    web3 = Web3(HTTPProvider(eth_rpc_endpoint))
+
+    reclaim_amount = 0
+
+    log.info("Checking chain")
+    for address, privkey in reclamation_candidates.items():
+        client = JSONRPCClient(web3, privkey)
+        token = CustomToken(client, token_address, contract_manager, "latest")
+
+        balance = token.balance_of(to_canonical_address(address))
+        log.debug(
+            "balance", token=to_checksum_address(token_address), balance=balance, address=address
+        )
+        if balance > 0:
+            drain_amount = balance
+            log.info(
+                "Reclaiming tokens", from_address=address, amount=drain_amount.__format__(",d")
+            )
+            reclaim_amount += drain_amount
+            assert account.address
+            try:
+                token.transfer(account.address, TokenAmount(drain_amount))
+            except InsufficientEth:
+                log.warning(
+                    "Not sufficient eth in node wallet to reclaim",
+                    address=address,
+                    token_address=token_address,
+                )
+                continue
+
+    log.info(
+        "Reclaimed", reclaim_amount=reclaim_amount.__format__(",d"), token_address=token.address
+    )
+
+
+def reclaim_eth(
+    reclamation_candidates: Dict[ChecksumAddress, PrivateKey],
+    account: Account,
+    eth_rpc_endpoint: URI,
+):
+    web3 = Web3(HTTPProvider(eth_rpc_endpoint))
 
     txs = []
     reclaim_amount = 0
@@ -152,12 +293,9 @@ def reclaim_eth(
     reclaim_tx_cost = gas_price * VALUE_TX_GAS_COST
 
     log.info("Checking chain")
-    for address, keyfile_content in address_to_keyfile.items():
+    for address, privkey in reclamation_candidates.items():
         balance = web3.eth.getBalance(address)
         if balance > reclaim_tx_cost:
-            if address not in address_to_privkey:
-                address_to_privkey[address] = decode_keyfile_json(keyfile_content, b"")
-            privkey = address_to_privkey[address]
             drain_amount = balance - reclaim_tx_cost
             log.info("Reclaiming", from_address=address, amount=drain_amount.__format__(",d"))
             reclaim_amount += drain_amount

--- a/scenario_player/utils/legacy.py
+++ b/scenario_player/utils/legacy.py
@@ -2,6 +2,7 @@ import json
 import os
 import pathlib
 import time
+from dataclasses import dataclass
 from itertools import chain as iter_chain
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -13,25 +14,19 @@ from eth_keyfile import decode_keyfile_json
 from eth_typing import URI
 from eth_utils import encode_hex, to_canonical_address, to_checksum_address
 from raiden_contracts.contract_manager import ContractManager, get_contracts_deployment_info
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter  # ugly import, it'll be in py3.8
 from web3 import HTTPProvider, Web3
 from web3.exceptions import TransactionNotFound
 from web3.types import TxReceipt
 
 from raiden.accounts import Account
 from raiden.exceptions import InsufficientEth
+from raiden.messages.abstract import cached_property
 from raiden.network.proxies.custom_token import CustomToken
 from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.network.rpc.client import EthTransfer, JSONRPCClient, TransactionSent
 from raiden.settings import RAIDEN_CONTRACT_VERSION
-from raiden.utils.typing import (
-    BlockNumber,
-    ChainID,
-    ChecksumAddress,
-    PrivateKey,
-    TokenAddress,
-    TokenAmount,
-)
+from raiden.utils.typing import BlockNumber, ChainID, ChecksumAddress, TokenAddress, TokenAmount
 from scenario_player.exceptions import ScenarioTxError
 from scenario_player.utils.contracts import (
     get_proxy_manager,
@@ -123,10 +118,25 @@ def wait_for_txs(web3: Web3, transactions: Iterable[TransactionSent], timeout: i
         raise ScenarioTxError(f"Timeout waiting for txhashes: {txhashes_str}")
 
 
-def get_keyfiles(data_path: pathlib.Path, min_age_hours: int) -> Dict[ChecksumAddress, dict]:
-    address_to_keyfile: Dict[ChecksumAddress, dict] = dict()
+@dataclass
+class ReclamationCandidate:
+    address: ChecksumAddress
+    keyfile_content: dict
+    node_dir: pathlib.Path
+
+    @cached_property
+    def privkey(self):
+        return decode_keyfile_json(self.keyfile_content, b"")
+
+
+def get_reclamation_candidates(
+    data_path: pathlib.Path, min_age_hours: int
+) -> List[ReclamationCandidate]:
+    candidates: List[ReclamationCandidate] = []
     for node_dir in iter_chain(data_path.glob("**/node_???"), data_path.glob("**/node_*_???")):
-        scenario_name: Path = Path(node_dir.parent.name)
+        if (node_dir / "reclaimed").exists():
+            continue
+
         last_run = next(
             iter(
                 sorted(
@@ -141,6 +151,7 @@ def get_keyfiles(data_path: pathlib.Path, min_age_hours: int) -> Dict[ChecksumAd
         if last_run:
             age_hours = (time.time() - last_run.stat().st_mtime) / 3600
             if age_hours < min_age_hours:
+                scenario_name: Path = Path(node_dir.parent.name)
                 log.debug(
                     "Skipping too recent node",
                     scenario_name=scenario_name,
@@ -152,22 +163,18 @@ def get_keyfiles(data_path: pathlib.Path, min_age_hours: int) -> Dict[ChecksumAd
             keyfile_content = json.loads(keyfile.read_text())
             address = keyfile_content.get("address")
             if address:
-                address_to_keyfile[to_checksum_address(address)] = keyfile_content
-    return address_to_keyfile
-
-
-def get_reclamation_candidates(
-    data_path: pathlib.Path, min_age_hours: int
-) -> Dict[ChecksumAddress, PrivateKey]:
-    address_to_keyfile = get_keyfiles(data_path, min_age_hours)
-    return {
-        address: decode_keyfile_json(keyfile_content, b"")
-        for address, keyfile_content in address_to_keyfile.items()
-    }
+                candidates.append(
+                    ReclamationCandidate(
+                        address=to_checksum_address(address),
+                        node_dir=node_dir,
+                        keyfile_content=keyfile_content,
+                    )
+                )
+    return candidates
 
 
 def withdraw_from_udc(
-    reclamation_candidates: Dict[ChecksumAddress, PrivateKey],
+    reclamation_candidates: List[ReclamationCandidate],
     contract_manager: ContractManager,
     account: Account,
     eth_rpc_endpoint: URI,
@@ -181,34 +188,38 @@ def withdraw_from_udc(
     planned_withdraws: Dict[ChecksumAddress, Tuple[BlockNumber, TokenAmount]] = dict()
 
     log.info("Checking chain for deposits in UserDeposit contact")
-    for address, privkey in reclamation_candidates.items():
-        if address not in address_to_proxy_manager:
-            client = JSONRPCClient(web3, privkey)
-            address_to_proxy_manager[address] = get_proxy_manager(client, deploy)
-        proxy_manager = address_to_proxy_manager[address]
+    for node in reclamation_candidates:
+        if node.address not in address_to_proxy_manager:
+            client = JSONRPCClient(web3, node.privkey)
+            address_to_proxy_manager[node.address] = get_proxy_manager(client, deploy)
+        proxy_manager = address_to_proxy_manager[node.address]
         (userdeposit_proxy, user_token_proxy) = get_udc_and_corresponding_token_from_dependencies(
             chain_id=chain_id, proxy_manager=proxy_manager
         )
 
-        balance = userdeposit_proxy.get_total_deposit(to_canonical_address(address), "latest")
-        log.debug("UDC balance", balance=balance, address=address)
+        balance = userdeposit_proxy.get_total_deposit(to_canonical_address(node.address), "latest")
+        log.debug("UDC balance", balance=balance, address=node.address)
         if balance > 0:
             drain_amount = TokenAmount(balance)
             log.info(
-                "Planning withdraw", from_address=address, amount=drain_amount.__format__(",d")
+                "Planning withdraw",
+                from_address=node.address,
+                amount=drain_amount.__format__(",d"),
             )
             try:
                 ready_at_block = userdeposit_proxy.plan_withdraw(drain_amount, "latest")
             except InsufficientEth:
-                log.warning("Not sufficient eth in node wallet to withdraw", address=address)
+                log.warning("Not sufficient eth in node wallet to withdraw", address=node.address)
                 continue
-            planned_withdraws[address] = ready_at_block, drain_amount
+            planned_withdraws[node.address] = ready_at_block, drain_amount
 
-    if planned_withdraws:
-        log.info(
-            "Withdraws successfully planned, waiting until withdraws are ready",
-            planned_withdraws=planned_withdraws,
-        )
+    if not planned_withdraws:
+        return
+
+    log.info(
+        "Withdraws successfully planned, waiting until withdraws are ready",
+        planned_withdraws=planned_withdraws,
+    )
 
     reclaim_amount = 0
     for address, (ready_at_block, amount) in planned_withdraws.items():
@@ -239,7 +250,7 @@ def withdraw_from_udc(
 
 
 def reclaim_erc20(
-    reclamation_candidates: Dict[ChecksumAddress, PrivateKey],
+    reclamation_candidates: List[ReclamationCandidate],
     token_address: TokenAddress,
     contract_manager: ContractManager,
     account: Account,
@@ -250,18 +261,23 @@ def reclaim_erc20(
     reclaim_amount = 0
 
     log.info("Checking chain")
-    for address, privkey in reclamation_candidates.items():
-        client = JSONRPCClient(web3, privkey)
+    for node in reclamation_candidates:
+        client = JSONRPCClient(web3, node.privkey)
         token = CustomToken(client, token_address, contract_manager, "latest")
 
-        balance = token.balance_of(to_canonical_address(address))
+        balance = token.balance_of(to_canonical_address(node.address))
         log.debug(
-            "balance", token=to_checksum_address(token_address), balance=balance, address=address
+            "balance",
+            token=to_checksum_address(token_address),
+            balance=balance,
+            address=node.address,
         )
         if balance > 0:
             drain_amount = balance
             log.info(
-                "Reclaiming tokens", from_address=address, amount=drain_amount.__format__(",d")
+                "Reclaiming tokens",
+                from_address=node.address,
+                amount=drain_amount.__format__(",d"),
             )
             reclaim_amount += drain_amount
             assert account.address
@@ -270,20 +286,21 @@ def reclaim_erc20(
             except InsufficientEth:
                 log.warning(
                     "Not sufficient eth in node wallet to reclaim",
-                    address=address,
+                    address=node.address,
                     token_address=token_address,
                 )
                 continue
 
-    log.info(
-        "Reclaimed", reclaim_amount=reclaim_amount.__format__(",d"), token_address=token.address
-    )
+    if reclaim_amount:
+        log.info(
+            "Reclaimed",
+            reclaim_amount=reclaim_amount.__format__(",d"),
+            token_address=token.address,
+        )
 
 
 def reclaim_eth(
-    reclamation_candidates: Dict[ChecksumAddress, PrivateKey],
-    account: Account,
-    eth_rpc_endpoint: URI,
+    reclamation_candidates: List[ReclamationCandidate], account: Account, eth_rpc_endpoint: URI
 ):
     web3 = Web3(HTTPProvider(eth_rpc_endpoint))
 
@@ -293,13 +310,13 @@ def reclaim_eth(
     reclaim_tx_cost = gas_price * VALUE_TX_GAS_COST
 
     log.info("Checking chain")
-    for address, privkey in reclamation_candidates.items():
-        balance = web3.eth.getBalance(address)
+    for node in reclamation_candidates:
+        balance = web3.eth.getBalance(node.address)
         if balance > reclaim_tx_cost:
             drain_amount = balance - reclaim_tx_cost
-            log.info("Reclaiming", from_address=address, amount=drain_amount.__format__(",d"))
+            log.info("Reclaiming", from_address=node.address, amount=drain_amount.__format__(",d"))
             reclaim_amount += drain_amount
-            client = JSONRPCClient(web3, privkey)
+            client = JSONRPCClient(web3, node.privkey)
             assert account.address
             txs.append(
                 client.transact(
@@ -308,6 +325,7 @@ def reclaim_eth(
                     )
                 )
             )
+        (node.node_dir / "reclaimed").touch()
 
     wait_for_txs(web3, txs, 1000)
     log.info("Reclaimed", reclaim_amount=reclaim_amount.__format__(",d"))


### PR DESCRIPTION
This is unnecessary when we use mintable tokens, but when testing with
real tokes on mainnet, this recovers valuable tokens. Without the new
cli parameters, the reclaim script has the old behavior.

This implementation is quite slow and could be sped up by creating
transactions in parallel. But reclaiming on mainnet should be rare, so
the current simple approach should be sufficient.

Will not work until https://github.com/raiden-network/raiden/pull/6091 is merged.

Closes https://github.com/raiden-network/scenario-player/issues/543