### PR TITLE
Don't deposit if approve/mint failed

### DIFF
--- a/scenario_player/utils/token.py
+++ b/scenario_player/utils/token.py
@@ -112,7 +112,7 @@ def userdeposit_maybe_deposit(
         new_total_deposit = TokenAmount(current_total_deposit + topup_amount)
 
         # Wait for mint transactions, if necessary
-        gevent.wait(mint_greenlets)
+        gevent.joinall(mint_greenlets, raise_error=True)
 
         userdeposit_proxy.deposit(
             target_address, new_total_deposit, userdeposit_proxy.client.get_confirmed_blockhash()


### PR DESCRIPTION
If approve or mint failed, an exception is raised. When this happens
the deposit should be stopped. This is achieved by re-raising the
exception instead of continuing execution.

This is part of https://github.com/raiden-network/scenario-player/issues/548 , the error message is correct, the problem is that approve failed and the deposit was sent nevertheless.  This does not fix whatever caused the failure in the approve transactions, but it makes sure to not send deposit to avoid hiding the original error.