### PR TITLE
Use local matrix server in smoke test

### DIFF
--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -589,7 +589,7 @@ def smoketest(ctx: Context, eth_client: EthClient):
                 env = EnvironmentConfig(
                     pfs_fee=FeeAmount(100),
                     environment_type="development",
-                    matrix_servers=["auto"],
+                    matrix_servers=[setup.args["matrix_server"]],
                     transfer_token=TokenAddress(bytes([1] * 20)),
                     pfs_with_fee=URI("http://www.example.com"),
                     eth_rpc_endpoints=[URI(setup.args["eth_rpc_endpoint"])],


### PR DESCRIPTION
Previously, it used the public matrix server, which is not intended in
the smoketest. Unfortunately, the local server does not have the correct
room setup, yet. So another commit is needed to fix that.

The error is
```
Could not join broadcast room #raiden_smoketest_monitoring:localhost:27856. Make sure the Matrix server you're trying to connect to uses the recommended server setup, esp. the server-side broadcast room creation. See https://github.com/raiden-network/raiden-transport.
```

Without this change, the smoketest is flaky, depending on the availability of the public matrix server.