### PR TITLE
Added time for synchronization

### DIFF
--- a/scenario_player/tasks/blockchain.py
+++ b/scenario_player/tasks/blockchain.py
@@ -114,6 +114,7 @@ class AssertBlockchainEventsTask(Task):
     """
 
     _name = "assert_events"
+    SYNCHRONIZATION_TIME_SECONDS = 0
 
     def __init__(
         self, runner: scenario_runner.ScenarioRunner, config: Any, parent: "Task" = None
@@ -186,6 +187,7 @@ class AssertBlockchainEventsTask(Task):
 
 class AssertMSClaimTask(Task):
     _name = "assert_ms_claim"
+    SYNCHRONIZATION_TIME_SECONDS = 0
 
     def __init__(
         self, runner: scenario_runner.ScenarioRunner, config: Any, parent: Task = None

--- a/scenario_player/tasks/channels.py
+++ b/scenario_player/tasks/channels.py
@@ -142,6 +142,7 @@ class StoreChannelInfoTask(ChannelActionTask):
 class AssertTask(ChannelActionTask):
     _name = "assert"
     _method = "get"
+    SYNCHRONIZATION_TIME_SECONDS = 0
 
     def _process_response(self, response_dict: dict):
         response_dict = super()._process_response(response_dict)

--- a/scenario_player/tasks/execution.py
+++ b/scenario_player/tasks/execution.py
@@ -14,6 +14,7 @@ log = structlog.get_logger(__name__)
 
 class SerialTask(Task):
     _name = "serial"
+    SYNCHRONIZATION_TIME_SECONDS = 0
 
     def __init__(
         self, runner: scenario_runner.ScenarioRunner, config: Any, parent: "Task" = None
@@ -50,6 +51,7 @@ class SerialTask(Task):
 
 
 class ParallelTask(SerialTask):
+    SYNCHRONIZATION_TIME_SECONDS = 0
     _name = "parallel"
 
     def _run(self, *args, **kwargs):
@@ -61,6 +63,7 @@ class ParallelTask(SerialTask):
 
 class WaitTask(Task):
     _name = "wait"
+    SYNCHRONIZATION_TIME_SECONDS = 0
 
     def _run(self, *args, **kwargs):  # pylint: disable=unused-argument
         gevent.sleep(self._config)
@@ -68,6 +71,7 @@ class WaitTask(Task):
 
 class WaitBlocksTask(Task):
     _name = "wait_blocks"
+    SYNCHRONIZATION_TIME_SECONDS = 0
 
     def _run(self, *args, **kwargs):  # pylint: disable=unused-argument
         web3 = self._runner.client.web3


### PR DESCRIPTION
Adding wait time for every task with side effects. The time has to be large enough to account for a slow run, specially for parallel runs of all the scenarios that can be particularly stressful for the ethereum nodes and the services.