### PR TITLE
Raiddit claims support

### DIFF
--- a/examples/raiddit.yaml
+++ b/examples/raiddit.yaml
@@ -1,0 +1,54 @@
+version: 2
+
+settings:
+  gas_price: "fast"
+  chain: any
+  claims:
+    enabled: true
+    hub-node: 1
+    additional-address-count: 100
+
+token:
+  balance_fund: 10_000_000_000_000_000_000
+  balance_min:   5_000_000_000_000_000_000
+  reuse: true
+
+nodes:
+  count: 3
+  raiden_version: local
+  reuse_accounts: true
+  restore_snapshot: true
+
+  default_options:
+    gas-price: fast
+    environment-type: development
+    routing-mode: private
+    enable-monitoring: false
+    default-settle-timeout: 40
+    default-reveal-timeout: 20
+
+scenario:
+  serial:
+    tasks:
+      - snapshot:
+          # We use the snapshot feature to ensure clean node state on every run.
+          # But since the channels are implicitly opened via the claims we don't actually need a
+          # task in here which is the reason for the "dummy" wait task.
+          tasks:
+            - wait: 0
+      - parallel:
+          name: "Assert after channel openings"
+          tasks:
+            - assert: {from: 0, to: 1, total_deposit: 100, balance: 100, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 100, balance: 100, state: "opened"}
+      - parallel:
+          name: "Make a transfer"
+          tasks:
+            - transfer: {from: 0, to: 1, amount: 42}
+            - transfer: {from: 2, to: 1, amount: 42}
+            - transfer: {from: 0, to: 2, amount: 42}
+      - parallel:
+          name: "Assert after transfer"
+          tasks:
+            - assert: {from: 0, to: 1, total_deposit: 100, balance: 14, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 100, balance: 102, state: "opened"}

--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -12,7 +12,7 @@ from io import StringIO
 from itertools import cycle, islice
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import IO, List, Sequence
+from typing import IO, List, Sequence, Union
 
 import click
 import gevent
@@ -29,17 +29,18 @@ from raiden_contracts.contract_manager import (
     DeployedContracts,
     contracts_precompiled_path,
 )
+from typing_extensions import Literal
 from urwid import ExitMainLoop
 from web3 import HTTPProvider, Web3
 from web3.middleware import simple_cache_middleware
 
 import scenario_player.utils
 from raiden.accounts import Account
-from raiden.constants import Environment, EthClient
+from raiden.constants import EthClient
 from raiden.log_config import _FIRST_PARTY_PACKAGES, configure_logging
 from raiden.network.rpc.client import make_sane_poa_middleware
 from raiden.network.rpc.middleware import faster_gas_price_strategy
-from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS, RAIDEN_CONTRACT_VERSION
+from raiden.settings import RAIDEN_CONTRACT_VERSION
 from raiden.utils.cli import AddressType, EnumChoiceType, get_matrix_servers, option
 from raiden.utils.typing import (
     TYPE_CHECKING,
@@ -264,13 +265,12 @@ def _load_environment(environment_file: IO) -> EnvironmentConfig:
     environment = json.load(environment_file)
     assert isinstance(environment, dict)
 
-    matrix_server_list = environment.pop(
-        "matrix_server_list",
-        DEFAULT_MATRIX_KNOWN_SERVERS[Environment(environment["environment_type"])],
-    )
-    matrix_servers: Sequence[URI] = get_matrix_servers(matrix_server_list)  # type: ignore
-    if len(matrix_servers) < 4:
-        matrix_servers = list(islice(cycle(matrix_servers), 4))
+    matrix_server_list = environment.pop("matrix_server_list", None)
+    matrix_servers: Sequence[Union[URI, Literal["auto"]]] = ["auto"]
+    if matrix_server_list is not None:
+        matrix_servers = get_matrix_servers(matrix_server_list)
+        if len(matrix_servers) < 4:
+            matrix_servers = list(islice(cycle(matrix_servers), 4))
 
     return EnvironmentConfig(
         matrix_servers=matrix_servers, environment_file_name=environment_file.name, **environment
@@ -385,7 +385,6 @@ def run_(
         )
         exit(exit_code)
     else:
-        success.set()
         exit_code = 0
         log.info("Run finished", result="success")
         report.update(dict(subject=f"Scenario successful {scenario_file.name}", message="Success"))
@@ -416,13 +415,13 @@ def orchestrate(
         data_path=scenario_runner_args.data_path,
         scenario_file=scenario_runner_args.scenario_file,
         environment=scenario_runner_args.environment,
+        success=success,
         smoketest_deployment_data=scenario_runner_args.smoketest_deployment_data,
         delete_snapshots=scenario_runner_args.delete_snapshots,
     )
+    ui: AbstractContextManager
     if enable_ui:
-        ui: AbstractContextManager = ScenarioUIManager(
-            scenario_runner, log_buffer, log_file_name, success
-        )
+        ui = ScenarioUIManager(scenario_runner, log_buffer, log_file_name, success)
     else:
         ui = nullcontext()
     log.info("Startup complete")
@@ -430,7 +429,7 @@ def orchestrate(
         scenario_runner.run_scenario()
 
 
-class ScenarioUIManager:
+class ScenarioUIManager(AbstractContextManager):
     def __init__(self, runner, log_buffer, log_file_name, success):
         self.ui = ScenarioUI(runner, log_buffer, log_file_name)
         self.success = success

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -525,6 +525,8 @@ class NodeController:
         return self._node_runners.__len__()
 
     def start(self, wait=True):
+        from scenario_player.runner import wait_for_nodes_to_be_ready
+
         log.info("Starting nodes")
 
         # Start nodes in <number of cpus> batches
@@ -534,6 +536,7 @@ class NodeController:
             for runner in self._node_runners:
                 pool.spawn(runner.start)
             pool.join(raise_error=True)
+            wait_for_nodes_to_be_ready(self._node_runners, self._runner.session)
             log.info("All nodes started")
 
         starter = gevent.spawn(_start)

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -42,6 +42,7 @@ RAIDEN_RELEASES_VERSIONED_NAME_TEMPLATE = "raiden-v{version}-{platform}-{arch}.z
 MANAGED_CONFIG_OPTIONS = {
     "accept-disclaimer",
     "address",
+    "claims-file-path",
     "config-file",
     "datadir",
     "disable-debug-logfile",
@@ -180,6 +181,8 @@ class NodeRunner:
         self._address: Optional[ChecksumAddress] = None
         self._api_address: Optional[str] = None
 
+        self.claims_file: Optional[Path] = None
+
         self._output_files: Dict[str, IO] = {}
 
         if options.pop("_clean", False):
@@ -272,6 +275,9 @@ class NodeRunner:
         pfs_address = self._pfs_address
         if pfs_address:
             cmd.extend(["--pathfinding-service-address", pfs_address])
+
+        if self.claims_file is not None and self.claims_file.exists():
+            cmd.extend(["--claims-file-path", str(self.claims_file.absolute())])
 
         for option_name in MANAGED_CONFIG_OPTIONS_OVERRIDABLE:
             if option_name in ("api-address", "pathfinding-service-address", "matrix-server"):

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -10,6 +10,7 @@ import structlog
 from eth_typing import ChecksumAddress
 from eth_utils import encode_hex, is_checksum_address, to_checksum_address, to_hex
 from gevent import Greenlet
+from gevent.event import Event
 from gevent.pool import Pool
 from raiden_contracts.constants import (
     CHAINNAME_TO_ID,
@@ -236,6 +237,7 @@ class ScenarioRunner:
         data_path: Path,
         scenario_file: Path,
         environment: EnvironmentConfig,
+        success: Event,
         task_state_callback: Optional[
             Callable[["ScenarioRunner", "Task", "TaskState"], None]
         ] = None,
@@ -245,6 +247,7 @@ class ScenarioRunner:
         from scenario_player.node_support import RaidenReleaseKeeper
 
         self.auth = auth
+        self.success = success
 
         self.smoketest_deployment_data = smoketest_deployment_data
         self.delete_snapshots = delete_snapshots
@@ -364,6 +367,7 @@ class ScenarioRunner:
             # scenario to exit (successfully or not).
             greenlets = {scenario}
             gevent.joinall(greenlets, raise_error=True, count=1)
+        self.success.set()
 
     def setup_environment_and_run_main_task(self, node_addresses: Set[ChecksumAddress]) -> None:
         """ This will first make sure the on-chain state is setup properly, and

--- a/scenario_player/ui.py
+++ b/scenario_player/ui.py
@@ -270,8 +270,6 @@ class ScenarioUI:
             self._root_widget.body.focus.original_widget.original_widget.keypress(
                 self._loop.screen_size, key
             )
-        else:
-            log.info("key", key=key)
 
     def _update_log_box_title(self):
         if self._log_walker.at_end:

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -1,7 +1,7 @@
 import itertools
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterator, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Union
 
 import structlog
 from eth_typing import URI
@@ -190,6 +190,23 @@ class ServiceSettingsConfig:
         self.udc = UDCSettingsConfig(loaded_definition, environment)
 
 
+class ClaimsConfig:
+    def __init__(self, settings: Dict[str, Any]) -> None:
+        config = settings.get("claims", {})
+
+        self.enabled = config.get("enabled", False)
+        self.hub_node_index = int(config.get("hub-node", -1))
+        self.additional_address_count = int(config.get("additional-address-count", 0))
+
+    def __repr__(self) -> str:
+        return (
+            f"<ClaimsConfig "
+            f"enabled={self.enabled} "
+            f"hub-node={self.hub_node_index} "
+            f"additional-address-count={self.additional_address_count}>"
+        )
+
+
 class SettingsConfig:
     """Settings Configuration Setting interface and validator.
 
@@ -219,6 +236,7 @@ class SettingsConfig:
         settings = loaded_definition.get("settings", {})
         self.dict = settings
         self.services = ServiceSettingsConfig(loaded_definition, environment)
+        self.claims = ClaimsConfig(settings)
         self.validate()
         self.eth_rpc_endpoint_iterator: Iterator[URI]
         self.chain_id: ChainID


### PR DESCRIPTION
Add Raiddit claims support

Allows to define scenarios that generate and use raiddit claims.
See `examples/raiddit.yaml` for an example scenario.

Depends on raiden-network/raiden#6398