### PR TITLE
Fix free port generation under high concurrency

### DIFF
--- a/examples/raiddit-demo.yaml
+++ b/examples/raiddit-demo.yaml
@@ -1,25 +1,26 @@
+{% set token_amount = 100000 %}
 version: 2
 
 settings:
   gas_price: "fast"
   services:
       pfs:
-          url: "http://localhost:6000"
+          url: "{{ pfs_with_fee }}"
   chain: any
   claims:
     enabled: true
     hub-node: 0
     additional-address-count: 100
-    token_amount: 100_000
-    num_direct_channels: 7  # direct channels: (0, 1), (1, 2), (2, 3)
+    token_amount: {{ token_amount }}
+    num_direct_channels: 99  # direct channels: (0, 1), (1, 2), (2, 3)
 
 token:
-  balance_fund: 10_000_000_000_000_000_000
-  balance_min:   5_000_000_000_000_000_000
+  balance_fund: 10_000_000
+  balance_min:   5_000_000
   reuse: true
 
 nodes:
-  count: 8
+  count: 100
   raiden_version: local
   reuse_accounts: true
   restore_snapshot: true
@@ -31,7 +32,15 @@ nodes:
     enable-monitoring: false
     default-settle-timeout: 40
     default-reveal-timeout: 10
-
+    flat-fee:
+      - "{{ transfer_token }}"
+      - 0
+    proportional-fee:
+      - "{{ transfer_token }}"
+      - 0
+    proportional-imbalance-fee:
+      - "{{ transfer_token }}"
+      - 0
 scenario:
   serial:
     tasks:
@@ -44,32 +53,113 @@ scenario:
       - parallel:
           name: "Assert after channel openings"
           tasks:
-            {% for i in [0, 1, 2, 3, 4, 5, 6] %}
-            - assert: {from: {{i+1}}, to: {{i}}, total_deposit: 100_000, balance: 100_000, state: "opened"}
-            - assert: {from: {{i}}, to: {{i+1}}, total_deposit: 100_000, balance: 100_000, state: "opened"}
+            {% for i in range(99) %}
+            - assert: {from: {{ i + 1 }}, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: {{ i }}, to: {{ i + 1 }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor -%}
+            {%- for i in range(1, 100) %}
+            - assert: {from: {{ i }}, to: 0, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: 0, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
             {% endfor %}
-            {% for i in [1, 2, 3, 4, 5, 6] %}
-            - assert: {from: {{i}}, to: {{0}}, total_deposit: 100_000, balance: 100_000, state: "opened"}
-            - assert: {from: {{0}}, to: {{i}}, total_deposit: 100_000, balance: 100_000, state: "opened"}
+      - wait: 10
+      - serial:
+          name: "Transfers via HUB, serially"
+          tasks:
+            {% for i in range(1, 10) %}
+            - transfer: {from: {{ 100 - i }}, to: {{ i }}, amount: 1}
+            - transfer: {from: {{ i }}, to: {{ 100 - i }}, amount: 1}
+            {% endfor %}
+      - parallel:
+          name: "Check balances after serial hub transfers"
+          tasks:
+            {% for i in range(99) %}
+            - assert: {from: {{ i + 1 }}, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: {{ i }}, to: {{ i + 1 }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor -%}
+            {%- for i in range(1, 100) %}
+            - assert: {from: {{ i }}, to: 0, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: 0, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
             {% endfor %}
       - serial:
-          name: "Tons of transfers"
+          name: "Transfers via HUB, batched"
+          tasks:
+            {% for j in range(2, 100, 7) %}
+            - parallel:
+                name: "Batch {{ j }} - {{ j + 6 }}, forwards"
+                tasks:
+                  {% for i in range(7) %}
+                  - transfer: {from: {{ j + i }}, to: {{ [(j + 7 - i), 99]|min }}, amount: 1}
+                  {% endfor %}
+            {% endfor %}{% for j in range(2, 100, 7) %}
+            - parallel:
+                name: "Batch {{ j }} - {{ j + 6 }}, reverse"
+                tasks:
+                  {% for i in range(7) %}
+                  - transfer: {from: {{ [(j + 7 - i), 99]|min }}, to: {{ j + i }}, amount: 1}
+                  {% endfor %}
+            {% endfor %}
+      - parallel:
+          name: "Check balances after batched hub transfers"
+          tasks:
+            {% for i in range(99) %}
+            - assert: {from: {{ i + 1 }}, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: {{ i }}, to: {{ i + 1 }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor -%}
+            {%- for i in range(1, 100) %}
+            - assert: {from: {{ i }}, to: 0, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: 0, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor %}
+      - serial:
+          name: "Fully decentralized peer to peer transfers (5 batches of 980 each)"
           repeat: 5
           tasks:
             - parallel:
-                name: "Transfer batch"
+                name: "Batch of 980 transfers"
                 repeat: 10
                 tasks:
-                  {% for i in [1, 3, 5] %}
-                  - transfer: {from: {{i}}, to: {{i+1}}, amount: 1}
-                  - transfer: {from: {{i+1}}, to: {{i}}, amount: 1}
+                  {% for i in range(1, 99, 2) %}
+                  - transfer: {from: {{ i }}, to: {{ i + 1 }}, amount: 50 }
+                  - transfer: {from: {{ i + 1 }}, to: {{ i }}, amount: 50 }
                   {% endfor %}
       - parallel:
-          name: "Burn something"
+          name: "Check balances after decentralized transfers"
           tasks:
-            - burn: {from: 0, to: 1, total_burn: 10, expected_http_status: 200}
+            {% for i in range(1, 99) %}
+            - assert: {from: {{ i + 1 }}, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: {{ i }}, to: {{ i + 1 }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor -%}
+            {%- for i in range(1, 100) %}
+            - assert: {from: {{ i }}, to: 0, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: 0, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor %}
       - parallel:
-          name: "Assert after transfer"
+          name: "Decentralized peer to peer burning of tokens, forwards"
           tasks:
-            - assert: {from: 0, to: 1, total_deposit: 100_000, balance: 99_990, state: "opened"}
-            - assert: {from: 2, to: 1, total_deposit: 100_000, balance: 100_000, state: "opened"}
+            {% for i in range(1, 99, 2) %}
+            - burn: {from: {{ i }}, to: {{ i + 1 }}, total_burn: 60_000 }
+            {% endfor %}
+      - parallel:
+          name: "Decentralized peer to peer burning of tokens, reverse"
+          tasks:
+            {% for i in range(1, 99, 2) %}
+            - burn: {from: {{ i + 1 }}, to: {{ i }}, total_burn: 70_000 }
+            {% endfor %}
+      - parallel:
+          name: "Check balances after decentralized burning"
+          tasks:
+            {% for i in range(1, 99, 2) %}
+            - assert: {from: {{ i }}, to: {{ i + 1 }}, total_deposit: {{ token_amount }}, balance: 40_000, state: "opened"}
+            - assert: {from: {{ i + 1 }}, to: {{ i }}, total_deposit: {{ token_amount }}, balance: 30_000, state: "opened"}
+            {% endfor -%}
+            {%- for i in range(1, 100) %}
+            - assert: {from: {{ i }}, to: 0, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            - assert: {from: 0, to: {{ i }}, total_deposit: {{ token_amount }}, balance: {{ token_amount }}, state: "opened"}
+            {% endfor %}
+      - parallel:
+          name: "Close some channels"
+          tasks:
+            {% for i in range(1, 99, 6) %}
+            - close_channel: {from: {{ i }}, to: {{ i + 1 }}}
+            - close_channel: {from: {{ i }}, to: 0}
+            {% endfor %}
+      - wait_blocks: 30  # 20 blocks settle timeout + buffer

--- a/scenario_player/constants.py
+++ b/scenario_player/constants.py
@@ -5,8 +5,8 @@ from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_p
 DEFAULT_TOKEN_BALANCE_MIN = 5_000
 DEFAULT_TOKEN_BALANCE_FUND = 50_000
 OWN_ACCOUNT_BALANCE_MIN = 5 * 10 ** 17  # := 0.5 Eth
-NODE_ACCOUNT_BALANCE_MIN = 15 * 10 ** 16  # := 0.15 Eth
-NODE_ACCOUNT_BALANCE_FUND = 3 * 10 ** 17  # := 0.3 Eth
+NODE_ACCOUNT_BALANCE_MIN = 5 * 10 ** 15  # := 0.005 Eth
+NODE_ACCOUNT_BALANCE_FUND = 3 * 10 ** 16  # := 0.03 Eth
 TIMEOUT = 200
 API_URL_TOKEN_NETWORK_ADDRESS = "{protocol}://{target_host}/api/v1/tokens/{token_address}"
 MAX_RAIDEN_STARTUP_TIME = 2000  # seconds

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -201,7 +201,9 @@ class NodeRunner:
         _ = self._keystore_file  # noqa: F841
         _ = self._raiden_bin  # noqa: F841
 
-    def start(self):
+    def start(self, wait: bool = False):
+        from scenario_player.runner import wait_for_nodes_to_be_ready
+
         log.info(
             "Starting node",
             node=self._index,
@@ -216,6 +218,8 @@ class NodeRunner:
         self._output_files["stdout"].write(f"Command line: {' '.join(self._command)}\n")
 
         self._process = self.nursery.exec_under_watch(self._command, **self._output_files)
+        if wait:
+            wait_for_nodes_to_be_ready([self], self._runner.session)
 
     # FIXME: Make node stop configurable?
     def stop(self, timeout=600):  # 10 mins
@@ -557,7 +561,7 @@ class NodeController:
 
         def _start():
             for runner in self._node_runners:
-                pool.spawn(runner.start)
+                pool.spawn(runner.start, wait=True)
             pool.join(raise_error=True)
             wait_for_nodes_to_be_ready(self._node_runners, self._runner.session)
             log.info("All nodes started")

--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -336,7 +336,7 @@ class NodeRunner:
                 f"-{self._index}"
             ).encode()
             privkey = hashlib.sha256(seed).digest()
-            keystore_file.write_text(json.dumps(create_keyfile_json(privkey, b"")))
+            keystore_file.write_text(json.dumps(create_keyfile_json(privkey, b"", iterations=100)))
         else:
             log.debug("Reusing keystore", node=self._index)
         return keystore_file

--- a/scenario_player/ui.py
+++ b/scenario_player/ui.py
@@ -204,8 +204,8 @@ class ScenarioUI:
         self._root_widget = uwd.Frame(
             TabFocusSwitchingPile(
                 [
-                    uwd.AttrWrap(self._task_box, "default", focus_attr="focus"),
-                    uwd.AttrWrap(self._log_box, "default", focus_attr="focus"),
+                    ("weight", 2, uwd.AttrWrap(self._task_box, "default", focus_attr="focus")),
+                    ("weight", 1, uwd.AttrWrap(self._log_box, "default", focus_attr="focus")),
                 ],
                 focus_item=1,
             ),


### PR DESCRIPTION
When a lot of nodes are started simultaneously just asking the OS for a
free port can lead to conflicts due to port reuse.

This fixes that. See comment in the code for details.