### PR TITLE
Use private routing in smoketest

### DIFF
--- a/tests/smoketests/template.yaml
+++ b/tests/smoketests/template.yaml
@@ -15,7 +15,7 @@ nodes:
   default_options:
     gas-price: fast
     environment-type: development
-    routing-mode: local
+    routing-mode: private
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     enable-monitoring: false


### PR DESCRIPTION
The local routing is about to be removed. We can just use `private`
routing in the smoketest, instead.