### PR TITLE
Always load a server list

### DIFF
--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -11,7 +11,7 @@ from io import StringIO
 from itertools import cycle, islice
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import IO, List, Sequence, Union
+from typing import IO, List, Sequence
 
 import click
 import gevent
@@ -28,18 +28,17 @@ from raiden_contracts.contract_manager import (
     DeployedContracts,
     contracts_precompiled_path,
 )
-from typing_extensions import Literal
 from urwid import ExitMainLoop
 from web3 import HTTPProvider, Web3
 from web3.middleware import simple_cache_middleware
 
 import scenario_player.utils
 from raiden.accounts import Account
-from raiden.constants import EthClient
+from raiden.constants import Environment, EthClient
 from raiden.log_config import _FIRST_PARTY_PACKAGES, configure_logging
 from raiden.network.rpc.client import make_sane_poa_middleware
 from raiden.network.rpc.middleware import faster_gas_price_strategy
-from raiden.settings import RAIDEN_CONTRACT_VERSION
+from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS, RAIDEN_CONTRACT_VERSION
 from raiden.utils.cli import AddressType, EnumChoiceType, get_matrix_servers, option
 from raiden.utils.typing import (
     TYPE_CHECKING,
@@ -269,12 +268,13 @@ def _load_environment(environment_file: IO) -> EnvironmentConfig:
     environment = json.load(environment_file)
     assert isinstance(environment, dict)
 
-    matrix_server_list = environment.pop("matrix_server_list", None)
-    matrix_servers: Sequence[Union[URI, Literal["auto"]]] = ["auto"]
-    if matrix_server_list is not None:
-        matrix_servers = [URI(uri) for uri in get_matrix_servers(matrix_server_list)]
-        if len(matrix_servers) < 4:
-            matrix_servers = list(islice(cycle(matrix_servers), 4))
+    matrix_server_list = environment.pop(
+        "matrix_server_list",
+        DEFAULT_MATRIX_KNOWN_SERVERS[Environment(environment["environment_type"])],
+    )
+    matrix_servers: Sequence[URI] = get_matrix_servers(matrix_server_list)  # type: ignore
+    if len(matrix_servers) < 4:
+        matrix_servers = list(islice(cycle(matrix_servers), 4))
 
     return EnvironmentConfig(
         matrix_servers=matrix_servers, environment_file_name=environment_file.name, **environment


### PR DESCRIPTION
Some scenarios explicitly assign different matrix servers to raiden
nodes. For this to work, the SP needs a list of matrix serves. When
none is given, use the default server list for the given `environment`
key in the environment JSON file.

This undoes part of https://github.com/raiden-network/scenario-player/commit/7c051a12dd25d97d64b0687dc16620bd8f53de16

Closes https://github.com/raiden-network/scenario-player/issues/607.