### PR TITLE
Fix delayed returns from tasks

### DIFF
--- a/scenario_player/tasks/base.py
+++ b/scenario_player/tasks/base.py
@@ -126,11 +126,11 @@ class Task:
                                 return_val = self._run(*args, **kwargs)
                             except ScenarioAssertionError as ex:
                                 exception = ex
+                                log.debug("Assertion failed, retrying...", ex=str(exception))
 
                             if return_val:
                                 break
 
-                            log.debug("Assertion failed, retrying...", ex=str(exception))
                             sleep(1)
                 except Timeout:
                     log.debug("Timeout reached", ex=str(exception))

--- a/scenario_player/tasks/blockchain.py
+++ b/scenario_player/tasks/blockchain.py
@@ -152,7 +152,7 @@ class AssertBlockchainEventsTask(Task):
             except KeyError:
                 raise ScenarioError(f"Unknown contract name: {self.contract_name}")
 
-        assert self.contract_address
+        assert self.contract_address, "Contract address not set"
         events = query_blockchain_events(
             web3=self.web3,
             contract_manager=self._runner.contract_manager,
@@ -184,6 +184,8 @@ class AssertBlockchainEventsTask(Task):
                 f"Expected number of events ({self.num_events}) did not match the number "
                 f"of events found ({len(events)})"
             )
+
+        return {"events": events}
 
 
 class AssertMSClaimTask(Task):

--- a/scenario_player/tasks/services.py
+++ b/scenario_player/tasks/services.py
@@ -341,8 +341,7 @@ class AssertPFSIOUTask(RESTAPIActionTask):
         else:
             source_address = self._runner.get_node_address(source)
 
-        params = dict(pfs_url=pfs_url, source_address=source_address)
-        return params
+        return dict(pfs_url=pfs_url, source_address=source_address)
 
     def _process_response(self, response_dict: dict):
 
@@ -358,3 +357,4 @@ class AssertPFSIOUTask(RESTAPIActionTask):
                 raise ScenarioAssertionError(
                     f"Expected amount of {exp_iou_amount} but got {actual_iou_amount}."
                 )
+        return response_dict


### PR DESCRIPTION
Those tasks only threw in case of errors, but didn't return a value in
the happy case, which led to additional iterations.

Fixes #611 