### PR TITLE
Make raiden binary CLI arg overwrite environment file

### DIFF
--- a/scenario_player/main.py
+++ b/scenario_player/main.py
@@ -218,7 +218,9 @@ def main():
     help="Delete node snapshots for the given scenario if any are present.",
 )
 @click.option(
-    "--raiden-client", default="raiden", help="The client executable to use [default: 'raiden']"
+    "--raiden-client",
+    default=None,
+    help="The client executable to use [default set by `env` file]",
 )
 @environment_option
 @key_password_options
@@ -234,7 +236,7 @@ def run(
     password_file: str,
     environment: EnvironmentConfig,
     delete_snapshots: bool,
-    raiden_client: str,
+    raiden_client: Optional[str],
 ):
     """Execute a scenario as defined in scenario definition file.
     click entrypoint, this dispatches to `run_`.
@@ -293,7 +295,7 @@ def run_(
     log_file_name: str,
     environment: EnvironmentConfig,
     delete_snapshots: bool,
-    raiden_client: str,
+    raiden_client: Optional[str],
     smoketest_deployment_data=None,
 ) -> None:
     """Execute a scenario as defined in scenario definition file.
@@ -588,6 +590,7 @@ def smoketest(eth_client: EthClient):
                     eth_rpc_endpoints=[URI(setup.args["eth_rpc_endpoint"])],
                     ms_reward_with_margin=TokenAmount(1),
                     settlement_timeout_min=BlockTimeout(100),
+                    raiden_client="raiden",
                 )
                 try:
                     run_(

--- a/scenario_player/runner.py
+++ b/scenario_player/runner.py
@@ -238,7 +238,7 @@ class ScenarioRunner:
         scenario_file: Path,
         environment: EnvironmentConfig,
         success: Event,
-        raiden_client: str,
+        raiden_client: Optional[str],
         task_state_callback: Optional[
             Callable[["ScenarioRunner", "Task", "TaskState"], None]
         ] = None,
@@ -254,7 +254,7 @@ class ScenarioRunner:
         self.environment = environment
 
         # Set the client executable to use
-        if self.environment.raiden_client is None:
+        if raiden_client is not None:
             self.environment.raiden_client = raiden_client
 
         self.task_count = 0

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -37,7 +37,7 @@ class EnvironmentConfig:
     pfs_fee: FeeAmount
     ms_reward_with_margin: TokenAmount
     settlement_timeout_min: BlockTimeout
-    raiden_client: Optional[str] = field(default=None)
+    raiden_client: str
 
     def __post_init__(self):
         self.eth_rpc_endpoint_iterator = itertools.cycle(self.eth_rpc_endpoints)

--- a/tests/unittests/utils/configuration/test_settings.py
+++ b/tests/unittests/utils/configuration/test_settings.py
@@ -22,6 +22,7 @@ dummy_env = EnvironmentConfig(
     eth_rpc_endpoints=[URI("http://www.example.com")],
     ms_reward_with_margin=TokenAmount(1),
     settlement_timeout_min=BlockTimeout(100),
+    raiden_client="raiden",
 )
 
 


### PR DESCRIPTION
When given the CLI arg, the environment setting should be overwritten.

This will make running the light client easier.