### PR TITLE
Re-add removed `install-dev` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ mypy:
 install:
 	poetry install
 
+install-dev: install
+
 unit-tests:
 	pytest --cov=scenario_player
 


### PR DESCRIPTION
This is used by the Raiden SP smoke test. I thought about changing the
call in Raiden, but I like to have the consistency of having an
`install-dev` target in all repos, even if it is the same as `install`
for some.