### PR TITLE
Add poetry install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ format: isort black
 mypy:
 	mypy scenario_player tests
 
-install:
+have-poetry:
+	pip install poetry
+
+install: have-poetry
 	poetry install
 
 install-dev: install


### PR DESCRIPTION
`pip` is usually available with recent python installations, whereas `poetry` is not. I added a make target that ensures `poetry` is installed in the current environment.