### PR TITLE
Use geth for nightly runs as well

### DIFF
--- a/scenario_player/environment/development.json
+++ b/scenario_player/environment/development.json
@@ -2,7 +2,7 @@
     "environment_type": "development",
     "pfs_with_fee": "https://pfs.transport01.raiden.network",
     "eth_rpc_endpoints": [
-        "http://parity.goerli.ethnodes.brainbot.com:8545"
+        "http://geth.goerli.ethnodes.brainbot.com:8545"
     ],
     "transfer_token": "0x59105441977ecD9d805A4f5b060E34676F50F806",
     "pfs_fee": 50000000000000000,


### PR DESCRIPTION
Parity shows some problems, let's switch to `geth` for now.