### PR TITLE
Only overwrite default values when not present

### DIFF
--- a/scenario_player/definition.py
+++ b/scenario_player/definition.py
@@ -47,8 +47,12 @@ class ScenarioDefinition:
         # If the environment sets a list of matrix servers, the nodes must not
         # choose other servers, so let's set the first server from the list as
         # default.
-        self.nodes.dict["default_options"]["matrix-server"] = environment.matrix_servers[0]
-        self.nodes.dict["default_options"]["environment-type"] = environment.environment_type
+        self.nodes.dict["default_options"].setdefault(
+            "matrix-server", environment.matrix_servers[0]
+        )
+        self.nodes.dict["default_options"].setdefault(
+            "environment-type", environment.environment_type
+        )
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Fixes: #664

Now the default values for `matrix-server` and `environment-type`  will only be set as the default 
when the key is not present in the `ScenarioDefinition.nodes.dict` and therefore when it is not present in the scenario file