### PR TITLE
Add Makefile target to install local raiden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ install: have-poetry
 install-dev: have-poetry
 	poetry install
 
+install-local-raiden:
+	echo "This only works when Raiden is installed in ../raiden"
+	echo "If pip install -e ."
+	sed -i 's/^raiden = {.*/raiden = { path = "..\/raiden"}/' pyproject.toml
+	poetry update raiden
+	poetry install
+	echo "If you get pkg_resources.ContextualVersionConflict, you need to update your egg-info by calling 'pip install -e ../raiden'."
+
 format: style
 
 lint: mypy flake8 pylint black-check isort-check

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,14 @@ install-dev: have-poetry
 	poetry install
 
 install-local-raiden:
-	echo "This only works when Raiden is installed in ../raiden"
-	echo "If pip install -e ."
+ifeq (, $(wildcard ../raiden/.git))
+	echo "This only works when a Raiden source checkout is located in ../raiden"
+else
 	sed -i 's/^raiden = {.*/raiden = { path = "..\/raiden"}/' pyproject.toml
 	poetry update raiden
 	poetry install
 	echo "If you get pkg_resources.ContextualVersionConflict, you need to update your egg-info by calling 'pip install -e ../raiden'."
+endif
 
 format: style
 


### PR DESCRIPTION
This make it easier to run arbitrary raiden version on your local
machine. The path is hardcoded and might not work for everyone, but it
will be a helpful documentation even in that case.