### PR TITLE
Allow setting gas_price in env file

### DIFF
--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -38,6 +38,7 @@ class EnvironmentConfig:
     pfs_fee: FeeAmount
     ms_reward_with_margin: TokenAmount
     settlement_timeout_min: BlockTimeout
+    gas_price: Union[int, str]
     raiden_client: str
     wait_short: int
     wait_long: int

--- a/scenario_player/utils/configuration/settings.py
+++ b/scenario_player/utils/configuration/settings.py
@@ -38,11 +38,11 @@ class EnvironmentConfig:
     pfs_fee: FeeAmount
     ms_reward_with_margin: TokenAmount
     settlement_timeout_min: BlockTimeout
-    gas_price: Union[int, str]
     raiden_client: str
     wait_short: int
     wait_long: int
     development_environment: ContractDevEnvironment = ContractDevEnvironment.DEMO
+    gas_price: Union[int, str] = "fast"
 
     def __post_init__(self):
         self.eth_rpc_endpoint_iterator = itertools.cycle(self.eth_rpc_endpoints)


### PR DESCRIPTION
We've used `"fast"` all the time in the past, so having it as a default
should be fine. Without a default, the current scenarios are broken with
the current configs in this repo.

Cherry picked fc3ad46 from `higher_funding` branch to hopefully reduce merge conflicts.