### PR TITLE
Use geth node on goerli again

### DIFF
--- a/scenario_player/environment/development.json
+++ b/scenario_player/environment/development.json
@@ -3,6 +3,7 @@
     "development_environment": "unstable",
     "pfs_with_fee": "https://pfs.transport01.raiden.network",
     "eth_rpc_endpoints": [
+        "http://geth.goerli.ethnodes.brainbot.com:8545",
         "http://parity.goerli.ethnodes.brainbot.com:8545"
     ],
     "transfer_token": "0x59105441977ecD9d805A4f5b060E34676F50F806",


### PR DESCRIPTION
This was disabled when there were problems with out geth node and never
reenabled.