### PR TITLE
Send SIGUSR1 to client process on Timeout

### DIFF
--- a/scenario_player/node_support.py
+++ b/scenario_player/node_support.py
@@ -299,6 +299,14 @@ class NodeRunner:
     def nursery(self, value: Nursery):
         self._nursery = value
 
+    def send_debugging_signal(self):
+        """
+        This can be used to trigger the gevent debugging hook from raiden python client.
+        """
+        if self._process is not None:
+            if self._process.pid is not None:
+                os.kill(self._process.pid, signal.SIGUSR1)
+
 
 class SnapshotManager:
     def __init__(self, scenario_runner: "ScenarioRunner", node_runners: List[NodeRunner]) -> None:
@@ -469,3 +477,11 @@ class NodeController:
     def set_nursery(self, nursery: Nursery):
         for node_runner in self._node_runners:
             node_runner.nursery = nursery
+
+    def send_debugging_signal(self) -> None:
+        """
+        This triggers ``NodeRunner.send_debugging_signal`` on all ``_node_runners``,
+        for example when a task hits a ``Timeout``.
+        """
+        for runner in self._node_runners:
+            runner.send_debugging_signal()

--- a/scenario_player/tasks/base.py
+++ b/scenario_player/tasks/base.py
@@ -133,6 +133,7 @@ class Task:
 
                             sleep(1)
                 except Timeout:
+                    self._runner.node_controller.send_debugging_signal()
                     log.debug("Timeout reached", ex=str(exception))
                     if exception:
                         raise exception

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,3 +1,4 @@
+import sys
 from collections import defaultdict
 from typing import Dict
 from unittest.mock import MagicMock
@@ -8,12 +9,12 @@ import responses
 from eth_typing import ChecksumAddress
 from eth_utils.address import to_checksum_address
 from raiden_contracts.contract_manager import ContractManager
-from tests.unittests.constants import TEST_TOKEN_ADDRESS, TEST_TOKEN_NETWORK_ADDRESS
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils.formatting import to_canonical_address
 from raiden.utils.typing import Address
 from scenario_player.tasks.base import Task
+from tests.unittests.constants import TEST_TOKEN_ADDRESS, TEST_TOKEN_NETWORK_ADDRESS
 
 
 @pytest.fixture
@@ -103,6 +104,9 @@ class DummyNodeController:
     @property
     def address_to_index(self) -> Dict[ChecksumAddress, int]:
         return {runner.address: i for i, runner in enumerate(iter(self))}  # type: ignore
+
+    def send_debugging_signal(self) -> None:
+        sys.stderr.write("Debugging signal sent\n")
 
 
 @pytest.fixture


### PR DESCRIPTION
This will send `SIGUSR1` to all client processes when a task hits a
timeout. The intention is to trigger a debugging hook, installed in
the python client, to help with deadlock detection.

See
https://github.com/raiden-network/raiden/issues/7141#issuecomment-901757801
for reference.