### PR TITLE
Revert "Only use parity for now"

### DIFF
--- a/scenario_player/environment/development.json
+++ b/scenario_player/environment/development.json
@@ -3,6 +3,7 @@
     "development_environment": "unstable",
     "pfs_with_fee": "https://pfs.transport01.raiden.network",
     "eth_rpc_endpoints": [
+        "http://geth.goerli.ethnodes.brainbot.com:8545",
         "http://parity.goerli.ethnodes.brainbot.com:8545"
     ],
     "transfer_token": "0x59105441977ecD9d805A4f5b060E34676F50F806",


### PR DESCRIPTION
This reverts commit 6dcea1df6124fc12f8a2940683ad35ced83b4ae4.

geth is synced now, so use it again.